### PR TITLE
fixed issue 18

### DIFF
--- a/mkl_fft/_numpy_fft.py
+++ b/mkl_fft/_numpy_fft.py
@@ -1039,10 +1039,10 @@ def rfftn(a, s=None, axes=None, norm=None):
     if unitary:
         a = asarray(a)
         s, axes = _cook_nd_args(a, s, axes)
-        n_tot = numpy.prod([ s[ai] for ai in axes])
 
     output = mkl_fft.rfftn_numpy(a, s, axes)
     if unitary:
+        n_tot = prod(asarray(s, dtype=output.dtype))
         output *= 1 / sqrt(n_tot)
     return output
 


### PR DESCRIPTION
Fixes #18.

Using vanilla numpy:

```python
In [1]: import numpy as np
   ...: x = np.zeros([2, 3])
   ...: y = np.fft.fftpack.rfftn(x, axes=[1], norm='ortho')
   ...:
   ...:

In [2]: import mkl_fft, mkl_fft._numpy_fft

In [3]: y2 = mkl_fft._numpy_fft.rfftn(x, axes=[1], norm='ortho')

In [4]: np.allclose(y, y2)
Out[4]: True

In [5]: import numpy as np
   ...: x = np.ones([2, 3])
   ...: y = np.fft.fftpack.rfftn(x, axes=[1], norm='ortho')
   ...:
   ...:

In [6]: y2 = mkl_fft._numpy_fft.rfftn(x, axes=[1], norm='ortho')

In [7]: np.allclose(y, y2)
Out[7]: True
```
