### PR TITLE
BUGFIX: Issue #21

### DIFF
--- a/mkl_fft/src/mklfft.c.src
+++ b/mkl_fft/src/mklfft.c.src
@@ -281,6 +281,37 @@ __cached_notinplace_@DftiCompute_MODE@_@MKL_IN_TYPE@_@MKL_OUT_TYPE@(
 }
 /**end repeat**/
 
+inline npy_intp
+compute_distance(npy_intp *x_strides, npy_intp *x_shape, npy_intp x_itemsize, int x_rank, int i1, int i2) {
+    npy_intp st1, st2;
+    npy_intp sh1 = x_shape[i1], sh2 = x_shape[i2];
+    npy_intp min_s;
+    if (sh1 > 1 && sh2 > 1) {
+        st1 = x_strides[i1];
+	st2 = x_strides[i2];
+	min_s = (st1 > st2) ? st2 : st1;
+
+        return min_s;
+    } else {
+        int i;
+	npy_intp max_s;
+        max_s = x_itemsize;
+        for(i=0; i < x_rank; i++) {
+	    if (x_shape[i] > 1) {
+		if (max_s < x_strides[i]) max_s = x_strides[i];
+	    }
+	}
+	min_s = max_s;
+	for(i=i1; i <= i2; i++) {
+	    if (x_shape[i] > 1) {
+		if (min_s > x_strides[i]) min_s = x_strides[i];
+	    }
+	}
+    }
+
+    return min_s;
+}
+
 static NPY_INLINE int
 compute_strides_and_distances(
     PyArrayObject *x,
@@ -315,11 +346,9 @@ compute_strides_and_distances(
 	    npy_intp char_dist = 0;
             *num_fft_transfs = _to_mkl_long (x_size / x_shape[axis]);
             if (axis == 0) {
-                npy_intp s1 =  x_strides[1], s2 =  x_strides[x_rank-1];
-                char_dist = (s1 > s2) ? s2 : s1;
+		char_dist = compute_distance(x_strides, x_shape, x_itemsize, x_rank, 1, x_rank-1);
             } else {
-                npy_intp s1 = x_strides[0], s2 = x_strides[x_rank-2];
-                char_dist = (s1 > s2) ? s2 : s1;
+                char_dist = compute_distance(x_strides, x_shape, x_itemsize, x_rank, 0, x_rank-2);
             }
 
 	    *vec_dist = _to_mkl_long (char_dist / x_itemsize);
@@ -375,17 +404,11 @@ compute_strides_and_distances_inout(
 	    npy_intp char_dist_in = 0, char_dist_out = 0;
             *num_fft_transfs = _to_mkl_long (x_size / x_shape[axis]);
             if (axis == 0) {
-                npy_intp s1 = x_strides[1], s2 = x_strides[x_rank-1];
-                char_dist_in = (s1 > s2) ? s2 : s1;
-
-		s1 = y_strides[1];  s2 = y_strides[x_rank-1];
-		char_dist_out = (s1 > s2) ? s2 : s1;
+                char_dist_in = compute_distance(x_strides, x_shape, x_itemsize, x_rank, 1, x_rank-1);
+		char_dist_out = compute_distance(y_strides, y_shape, y_itemsize, x_rank, 1, x_rank-1);
             } else {
-                npy_intp s1 = x_strides[0], s2 = x_strides[x_rank-2];
-                char_dist_in = (s1 > s2) ? s2 : s1;
-
-		s1 = y_strides[0];  s2 = y_strides[x_rank-2];
-		char_dist_out = (s1 > s2) ? s2 : s1;
+                char_dist_in = compute_distance(x_strides, x_shape, x_itemsize, x_rank, 0, x_rank-2);
+		char_dist_out = compute_distance(y_strides, y_shape, y_itemsize, x_rank, 0, x_rank-2);
             }
 	    *vec_dist_in = _to_mkl_long (char_dist_in / x_itemsize);
 	    *vec_dist_out = _to_mkl_long (char_dist_out / y_itemsize);

--- a/mkl_fft/src/mklfft.c.src
+++ b/mkl_fft/src/mklfft.c.src
@@ -61,7 +61,7 @@ static npy_intp ar_size(npy_intp *sh, int len)
     int i;
 
     for(d=sh, i=0; i < len; i++, d++)
-	r *= *d;
+        r *= *d;
 
     return r;
 }
@@ -102,11 +102,11 @@ static struct DftiCache dftiCache = {NULL, NO};
 static void freeCache(void)
 {
     if(dftiCache.initialized && dftiCache.hand) {
-	MKL_LONG status = DftiFreeDescriptor(&dftiCache.hand);
+        MKL_LONG status = DftiFreeDescriptor(&dftiCache.hand);
 
-	_debug_print("Descriptor freed: %ld\n", status);
+        _debug_print("Descriptor freed: %ld\n", status);
 
-	assert(status == 0);
+        assert(status == 0);
     }
 }
 
@@ -121,42 +121,42 @@ __create_descriptor_1d_@prec@_@domain@(MKL_LONG len, @sc_t@ fsc, @sc_t@ bsc)
     MKL_LONG status = 0;
 
     if (dftiCache.initialized && dftiCache.hand) {
-	enum DFTI_CONFIG_VALUE cached_prec, cached_dom;
-	MKL_LONG cached_rank, cached_len;
-	@sc_t@ cached_sc;
+        enum DFTI_CONFIG_VALUE cached_prec, cached_dom;
+        MKL_LONG cached_rank, cached_len;
+        @sc_t@ cached_sc;
 
-	status = DftiGetValue(dftiCache.hand, DFTI_DIMENSION, &cached_rank);
-	if (0 != status || cached_rank != 1) goto reallocate;
+        status = DftiGetValue(dftiCache.hand, DFTI_DIMENSION, &cached_rank);
+        if (0 != status || cached_rank != 1) goto reallocate;
 
-	status = DftiGetValue(dftiCache.hand, DFTI_PRECISION, &cached_prec);
-	if (0 != status || cached_prec != @prec@) goto reallocate;
+        status = DftiGetValue(dftiCache.hand, DFTI_PRECISION, &cached_prec);
+        if (0 != status || cached_prec != @prec@) goto reallocate;
 
-	status = DftiGetValue(dftiCache.hand, DFTI_FORWARD_DOMAIN, &cached_dom);
-	if (0 != status || cached_dom != @domain@) goto reallocate;
+        status = DftiGetValue(dftiCache.hand, DFTI_FORWARD_DOMAIN, &cached_dom);
+        if (0 != status || cached_dom != @domain@) goto reallocate;
 
-	status = DftiGetValue(dftiCache.hand, DFTI_LENGTHS, &cached_len);
-	if (0 != status || cached_len != len) goto reallocate;
+        status = DftiGetValue(dftiCache.hand, DFTI_LENGTHS, &cached_len);
+        if (0 != status || cached_len != len) goto reallocate;
 
-	status = DftiGetValue(dftiCache.hand, DFTI_FORWARD_SCALE, &cached_sc);
-	if (0 != status || cached_sc != fsc) goto set_scales;
+        status = DftiGetValue(dftiCache.hand, DFTI_FORWARD_SCALE, &cached_sc);
+        if (0 != status || cached_sc != fsc) goto set_scales;
 
-	status = DftiGetValue(dftiCache.hand, DFTI_BACKWARD_SCALE, &cached_sc);
-	if (0 != status || cached_sc != bsc) goto set_scales;
+        status = DftiGetValue(dftiCache.hand, DFTI_BACKWARD_SCALE, &cached_sc);
+        if (0 != status || cached_sc != bsc) goto set_scales;
 
-	return status;
+        return status;
     }
 
   allocate_new:
     status =
-	DftiCreateDescriptor(
-	    &dftiCache.hand,
-	    @prec@,
-	    @domain@,
-	    1,
-	    len
-	);
+        DftiCreateDescriptor(
+            &dftiCache.hand,
+            @prec@,
+            @domain@,
+            1,
+            len
+        );
     if (!dftiCache.initialized) {
-	atexit(freeCache);
+        atexit(freeCache);
     }
     dftiCache.initialized = (status == 0) ? 1 : 0;
 
@@ -170,8 +170,8 @@ __create_descriptor_1d_@prec@_@domain@(MKL_LONG len, @sc_t@ fsc, @sc_t@ bsc)
 
   reallocate:
     if(dftiCache.hand) {
-	status = DftiFreeDescriptor(&dftiCache.hand);
-	assert(status == 0);
+        status = DftiFreeDescriptor(&dftiCache.hand);
+        assert(status == 0);
     }
 
     status = 0;
@@ -197,7 +197,7 @@ __set_descriptor_1d_value_longp(enum DFTI_CONFIG_PARAM par, MKL_LONG *val)
 
     status = DftiGetValue(dftiCache.hand, par, cached_val);
     if (0 == status && __longp_equal_1d(cached_val, val))
-	return status;
+        return status;
 
     status = DftiSetValue(dftiCache.hand, par, val);
 
@@ -218,7 +218,7 @@ __set_descriptor_1d_value_@TYPE_NAME@(enum DFTI_CONFIG_PARAM par, @type@ val)
 
     status = DftiGetValue(dftiCache.hand, par, &cached_val);
     if (0 == status && cached_val == val)
-	return status;
+        return status;
 
     status = DftiSetValue(dftiCache.hand, par, val);
 
@@ -236,7 +236,7 @@ __commit_descriptor_1d(void)
     status = DftiGetValue(dftiCache.hand, DFTI_COMMIT_STATUS, &cached_committed);
 
     if(0 == status && cached_committed == DFTI_COMMITTED)
-	return status;
+        return status;
 
     status = DftiCommitDescriptor(dftiCache.hand);
 
@@ -281,35 +281,58 @@ __cached_notinplace_@DftiCompute_MODE@_@MKL_IN_TYPE@_@MKL_OUT_TYPE@(
 }
 /**end repeat**/
 
-inline npy_intp
-compute_distance(npy_intp *x_strides, npy_intp *x_shape, npy_intp x_itemsize, int x_rank, int i1, int i2) {
+/*
+ * For an array, iterating though indexes [i1, i2), fixing others to zero,
+ * and _assuming_ these pointers form a regular lattice, compute distance
+ * between adjacent pointers on that lattice.
+ *
+ */
+static NPY_INLINE MKL_LONG
+compute_distance(npy_intp *x_strides, npy_intp *x_shape, npy_intp x_itemsize, int x_rank, int i1, int i2, int c_contig, int f_contig) {
+
+    if (c_contig) {
+        return (i1) ? 1 : _to_mkl_long(x_shape[x_rank-1]);
+    }
+
+    if (f_contig) {
+        return (i1) ? _to_mkl_long(x_shape[x_rank-1]) : 1;
+    }
+
+    /* Right now, this is dead branch of code, since compute_distance is only called if array is ONESEGMENT, 
+     * i.e. either C or F contiguous.
+     *     It is however preserved here, since in the future this may be called on a not any-contiguous array.
+     */
+    {
+
     npy_intp st1, st2;
     npy_intp sh1 = x_shape[i1], sh2 = x_shape[i2];
     npy_intp min_s;
+
     if (sh1 > 1 && sh2 > 1) {
         st1 = x_strides[i1];
-	st2 = x_strides[i2];
-	min_s = (st1 > st2) ? st2 : st1;
+        st2 = x_strides[i2];
+        min_s = (st1 > st2) ? st2 : st1;
 
-        return min_s;
+        return _to_mkl_long(min_s / x_itemsize);
     } else {
         int i;
-	npy_intp max_s;
+        npy_intp max_s;
         max_s = x_itemsize;
         for(i=0; i < x_rank; i++) {
-	    if (x_shape[i] > 1) {
-		if (max_s < x_strides[i]) max_s = x_strides[i];
-	    }
-	}
-	min_s = max_s;
-	for(i=i1; i <= i2; i++) {
-	    if (x_shape[i] > 1) {
-		if (min_s > x_strides[i]) min_s = x_strides[i];
-	    }
-	}
+            if (x_shape[i] > 1) {
+                if (max_s < x_strides[i]) max_s = x_strides[i];
+            }
+        }
+        min_s = max_s;
+        for(i=i1; i <= i2; i++) {
+            if (x_shape[i] > 1) {
+                if (min_s > x_strides[i]) min_s = x_strides[i];
+            }
+        }
     }
 
-    return min_s;
+    return _to_mkl_long(min_s / x_itemsize);
+    }
 }
 
 static NPY_INLINE int
@@ -340,18 +363,15 @@ compute_strides_and_distances(
         {
             int any_contig = (PyArray_ISONESEGMENT(x)) ? 1 : 0;
             single_DftiCompute =
-		(any_contig && (axis == 0 || axis == x_rank-1)) ? YES : NO;
+                (any_contig && (axis == 0 || axis == x_rank-1)) ? YES : NO;
         }
         if (single_DftiCompute) {
-	    npy_intp char_dist = 0;
-            *num_fft_transfs = _to_mkl_long (x_size / x_shape[axis]);
-            if (axis == 0) {
-		char_dist = compute_distance(x_strides, x_shape, x_itemsize, x_rank, 1, x_rank-1);
-            } else {
-                char_dist = compute_distance(x_strides, x_shape, x_itemsize, x_rank, 0, x_rank-2);
-            }
+            int i0 = (axis == 0);
+            int c_contig = PyArray_IS_C_CONTIGUOUS(x);
+            int f_contig = PyArray_IS_F_CONTIGUOUS(x);
 
-	    *vec_dist = _to_mkl_long (char_dist / x_itemsize);
+            *num_fft_transfs = _to_mkl_long (x_size / x_shape[axis]);
+            *vec_dist = compute_distance(x_strides, x_shape, x_itemsize, x_rank, i0, i0 + x_rank - 2, c_contig, f_contig);
         } else {
             /* input vectors need not be equidistant, checking if they are  *
              * may be expensive. Fall back on general iterations.           */
@@ -369,7 +389,7 @@ compute_strides_and_distances(
 /* x: input array, y: output array */
 static int
 compute_strides_and_distances_inout(
-    PyArrayObject *x,
+    PyArrayObject *x, PyArrayObject *y,
     int x_rank, npy_intp *x_shape, npy_intp *x_strides,
     npy_intp x_itemsize, npy_intp x_size, int axis,
     MKL_LONG *num_fft_transfs,
@@ -393,25 +413,24 @@ compute_strides_and_distances_inout(
         *vec_dist_out = _to_mkl_long (y_strides[1-axis] / y_itemsize);
         break;
     default:
-	assert(x_rank > 2);
+        assert(x_rank > 2);
         /* we must have C- or F- contiguous layout */
         {
             int any_contig = (PyArray_ISONESEGMENT(x)) ? 1 : 0;
             single_DftiCompute =
-		(any_contig && (axis == 0 || axis == x_rank-1)) ? YES : NO;
+                (any_contig && (axis == 0 || axis == x_rank-1)) ? YES : NO;
         }
         if (single_DftiCompute) {
-	    npy_intp char_dist_in = 0, char_dist_out = 0;
+            int i0 = (axis == 0);
+            int c_contig = PyArray_IS_C_CONTIGUOUS(x);
+            int f_contig = PyArray_IS_F_CONTIGUOUS(x);
+
             *num_fft_transfs = _to_mkl_long (x_size / x_shape[axis]);
-            if (axis == 0) {
-                char_dist_in = compute_distance(x_strides, x_shape, x_itemsize, x_rank, 1, x_rank-1);
-		char_dist_out = compute_distance(y_strides, y_shape, y_itemsize, x_rank, 1, x_rank-1);
-            } else {
-                char_dist_in = compute_distance(x_strides, x_shape, x_itemsize, x_rank, 0, x_rank-2);
-		char_dist_out = compute_distance(y_strides, y_shape, y_itemsize, x_rank, 0, x_rank-2);
-            }
-	    *vec_dist_in = _to_mkl_long (char_dist_in / x_itemsize);
-	    *vec_dist_out = _to_mkl_long (char_dist_out / y_itemsize);
+            *vec_dist_in = compute_distance(x_strides, x_shape, x_itemsize, x_rank, i0, i0 + x_rank - 2, c_contig, f_contig);
+
+            c_contig = PyArray_IS_C_CONTIGUOUS(y);
+            f_contig = PyArray_IS_F_CONTIGUOUS(y);
+            *vec_dist_out = compute_distance(y_strides, y_shape, y_itemsize, x_rank, i0, i0 + x_rank - 2, c_contig, f_contig); 
         } else {
             /* input vectors need not be equidistant, checking if they are  *
              * may be expensive. Fall back on general iterations.           */
@@ -440,7 +459,7 @@ compute_strides_and_distances_inout(
 int @name@_mkl_@mode@_in(PyArrayObject* x_inout, npy_intp n, int axis)
 {
     MKL_LONG status = 0, input_distance = 0,
-	     input_number_of_transforms = 1;
+             input_number_of_transforms = 1;
     @MKL_TYPE@ *x_data = 0;
     /* For 1D transformes strides is a length-2 array */
     MKL_LONG input_strides[2] = {0, 1};
@@ -450,7 +469,7 @@ int @name@_mkl_@mode@_in(PyArrayObject* x_inout, npy_intp n, int axis)
     npy_intp x_size, x_itemsize;
 
     get_basic_array_data(x_inout, &x_rank, &x_shape,
-			 &x_strides, &x_itemsize, &x_size);
+                         &x_strides, &x_itemsize, &x_size);
 
     assert( x_size > 0 ); /* assert that x is non-empty */
     assert( 0 <= axis && axis < x_rank );
@@ -465,17 +484,17 @@ int @name@_mkl_@mode@_in(PyArrayObject* x_inout, npy_intp n, int axis)
         for(i=0; i < x_rank; i++) {
             assert( (x_strides[i] % x_itemsize) == 0 );
         }
-	assert(input_strides[0] >= 0);
+        assert(input_strides[0] >= 0);
     }
 
     single_DftiCompute =
     compute_strides_and_distances(
-	x_inout,
-	x_rank, x_shape, x_strides, x_itemsize, x_size, axis,
-	&input_number_of_transforms, &input_distance);
+        x_inout,
+        x_rank, x_shape, x_strides, x_itemsize, x_size, axis,
+        &input_number_of_transforms, &input_distance);
 
     status = __create_descriptor_1d_@DFTI_PRECISION@_DFTI_COMPLEX(
-	_to_mkl_long(n), 1.0, 1.0/n);
+        _to_mkl_long(n), 1.0, 1.0/n);
     if (status != 0) goto failed;
 
     /* these must be always set, since previous cached element
@@ -484,67 +503,67 @@ int @name@_mkl_@mode@_in(PyArrayObject* x_inout, npy_intp n, int axis)
     if (status != 0) goto failed;
 
     status = __set_descriptor_1d_value_enum(
-	DFTI_COMPLEX_STORAGE, DFTI_COMPLEX_COMPLEX);
+        DFTI_COMPLEX_STORAGE, DFTI_COMPLEX_COMPLEX);
     if (status != 0) goto failed;
 
     status = __set_descriptor_1d_value_longp(
-	DFTI_INPUT_STRIDES, input_strides);
+        DFTI_INPUT_STRIDES, input_strides);
     if (status != 0) goto failed;
 
 
     if (input_number_of_transforms > 1) {
         status = __set_descriptor_1d_value_long(DFTI_NUMBER_OF_TRANSFORMS,
-						input_number_of_transforms);
-	if (status != 0) goto failed;
+                                                input_number_of_transforms);
+        if (status != 0) goto failed;
 
-	status = __set_descriptor_1d_value_long(
-	    DFTI_INPUT_DISTANCE, input_distance);
-	if (status != 0) goto failed;
+        status = __set_descriptor_1d_value_long(
+            DFTI_INPUT_DISTANCE, input_distance);
+        if (status != 0) goto failed;
     }
     else { /* it is important to set the number of transforms
-	      for cached descriptor */
+              for cached descriptor */
         status = __set_descriptor_1d_value_long(
-	    DFTI_NUMBER_OF_TRANSFORMS, input_number_of_transforms);
-	if (status != 0) goto failed;
+            DFTI_NUMBER_OF_TRANSFORMS, input_number_of_transforms);
+        if (status != 0) goto failed;
     }
 
     status = __commit_descriptor_1d();
     if (status != 0) goto failed;
 
     if (single_DftiCompute){
-	status = __cached_inplace_@DftiCompute_MODE@_@MKL_TYPE@(x_data);
-	if (status != 0) goto failed;
+        status = __cached_inplace_@DftiCompute_MODE@_@MKL_TYPE@(x_data);
+        if (status != 0) goto failed;
     } else {
-	multi_iter_masked_t *mit;
-	int *mask;
-	int i;
+        multi_iter_masked_t *mit;
+        int *mask;
+        int i;
 
-	mask = (int *) mkl_malloc((x_rank-1)*sizeof(int), 64);
+        mask = (int *) mkl_malloc((x_rank-1)*sizeof(int), 64);
 
-	for(i = 0; i < axis; i++) mask[i] = i;
-	for(i = axis + 1; i < x_rank; i++) mask[i-1] = i;
+        for(i = 0; i < axis; i++) mask[i] = i;
+        for(i = axis + 1; i < x_rank; i++) mask[i-1] = i;
 
-	mit = multi_iter_masked_new(x_shape, x_rank, mask, x_rank - 1);
+        mit = multi_iter_masked_new(x_shape, x_rank, mask, x_rank - 1);
 
-	while(!MultiIter_Done(mit)) {
-	    char *tmp;
+        while(!MultiIter_Done(mit)) {
+            char *tmp;
 
-	    for(tmp = (char *) x_data, i = 0; i < x_rank; i++)
-		tmp += x_strides[i] * MultiIter_IndexElem(mit, i);
+            for(tmp = (char *) x_data, i = 0; i < x_rank; i++)
+                tmp += x_strides[i] * MultiIter_IndexElem(mit, i);
 
-	    status = __cached_inplace_@DftiCompute_MODE@_@MKL_TYPE@(
-		(@MKL_TYPE@*) tmp);
-	    if (status != 0) break;
-	    
-	    if (multi_iter_masked_next(mit))
-		break;
-	}
+            status = __cached_inplace_@DftiCompute_MODE@_@MKL_TYPE@(
+                (@MKL_TYPE@*) tmp);
+            if (status != 0) break;
+
+            if (multi_iter_masked_next(mit))
+                break;
+        }
 
 
-	multi_iter_masked_free(mit);
-	mkl_free(mask);
+        multi_iter_masked_free(mit);
+        mkl_free(mask);
 
-	if (status != 0) goto failed;
+        if (status != 0) goto failed;
     }
 
 
@@ -578,15 +597,15 @@ int @REALIN@_@COMPLEXOUT@_mkl_@mode@_out(
     PyArrayObject *x_in, npy_intp n, int axis, PyArrayObject *x_out, int all_harmonics)
 {
     MKL_LONG status = 0, input_distance = 0,
-	     output_distance = 0, input_number_of_transforms = 1;
+             output_distance = 0, input_number_of_transforms = 1;
     @MKL_IN_TYPE@ *xin_data = 0;
     @MKL_OUT_TYPE@ *xout_data = 0;
     /* For 1D transformes strides is a length-2 array */
     MKL_LONG input_strides[2] = {0, 1};
     MKL_LONG output_strides[2] = {0, 1};
     npy_intp *xin_shape = 0,
-	     *xin_strides = 0,
-	     *xout_shape = 0,
+             *xin_strides = 0,
+             *xout_shape = 0,
              *xout_strides = 0;
     int i, xin_rank, xout_rank;
     int single_DftiCompute = NO;
@@ -597,9 +616,9 @@ int @REALIN@_@COMPLEXOUT@_mkl_@mode@_out(
     assert(x_out != NULL);
 
     get_basic_array_data(x_in, &xin_rank, &xin_shape,
-			 &xin_strides, &xin_itemsize, &xin_size);
+                         &xin_strides, &xin_itemsize, &xin_size);
     get_basic_array_data(x_out, &xout_rank, &xout_shape, &xout_strides,
-			 &xout_itemsize, &xout_size);
+                         &xout_itemsize, &xout_size);
 
     assert(xout_rank == xin_rank);
 
@@ -612,10 +631,10 @@ int @REALIN@_@COMPLEXOUT@_mkl_@mode@_out(
     assert(xout_itemsize = 2 * xin_itemsize);
 
     for(i=0; i < axis; i++)
-	assert(xin_shape[i] == xout_shape[i]);
+        assert(xin_shape[i] == xout_shape[i]);
     assert( xout_shape[axis] == (all_harmonics) ? n : n/2 + 1);
     for(i=axis+1; i < xin_rank; i++)
-	assert(xin_shape[i] == xout_shape[i]);
+        assert(xin_shape[i] == xout_shape[i]);
 
     /* output buffer is created in Cython as C_CONTIGUOUS */
     assert(PyArray_ISONESEGMENT(x_out));
@@ -625,49 +644,49 @@ int @REALIN@_@COMPLEXOUT@_mkl_@mode@_out(
     {
         char *tmp = (char *) xin_data;
         input_strides[1] =
-	    ((@MKL_IN_TYPE@*) (tmp + xin_strides[axis])) - xin_data;
+            ((@MKL_IN_TYPE@*) (tmp + xin_strides[axis])) - xin_data;
 
-	assert(input_strides[0] >= 0);
+        assert(input_strides[0] >= 0);
 
         for(i=0; i < xin_rank; i++) {
             assert( (xin_strides[i] % xin_itemsize) == 0 );
             assert( (xout_strides[i] % xout_itemsize) == 0 );
-	    assert( xout_strides[i] > 0 );
+            assert( xout_strides[i] > 0 );
         }
 
-	/* Compute output strides */
-	tmp = (char *) xout_data;
-	output_strides[1] =
-	    ((@MKL_OUT_TYPE@*) (tmp + xout_strides[axis])) - xout_data;
+        /* Compute output strides */
+        tmp = (char *) xout_data;
+        output_strides[1] =
+            ((@MKL_OUT_TYPE@*) (tmp + xout_strides[axis])) - xout_data;
     }
 
     single_DftiCompute =
-	compute_strides_and_distances_inout(
-	    x_in,
-	    xin_rank, xin_shape, xin_strides,
-	    xin_itemsize, xin_size, axis,
-	    &input_number_of_transforms,
-	    &input_distance,
-	    xout_shape, xout_strides, xout_itemsize,
-	    &output_distance
-	);
+        compute_strides_and_distances_inout(
+            x_in, x_out,
+            xin_rank, xin_shape, xin_strides,
+            xin_itemsize, xin_size, axis,
+            &input_number_of_transforms,
+            &input_distance,
+            xout_shape, xout_strides, xout_itemsize,
+            &output_distance
+        );
 
     if (@POST_CONJUGATE@) { /* we are doing IFFT using Forward computation, swap scales */
-	forward_scale = 1.0/n; 
-	backward_scale = 1.0;
+        forward_scale = 1.0/n;
+        backward_scale = 1.0;
     } else {
-	forward_scale = 1.0;
-	backward_scale = 1.0/n;
+        forward_scale = 1.0;
+        backward_scale = 1.0/n;
     }
     status = __create_descriptor_1d_@DFTI_PRECISION@_DFTI_REAL(
-	_to_mkl_long(n), forward_scale, backward_scale);
+        _to_mkl_long(n), forward_scale, backward_scale);
     if (status != 0) goto failed;
 
     status = __set_descriptor_1d_value_longp(DFTI_INPUT_STRIDES, input_strides);
     if (status != 0) goto failed;
 
     status = __set_descriptor_1d_value_enum(
-	DFTI_CONJUGATE_EVEN_STORAGE, DFTI_COMPLEX_COMPLEX);
+        DFTI_CONJUGATE_EVEN_STORAGE, DFTI_COMPLEX_COMPLEX);
     if (status != 0) goto failed;
 
     status = __set_descriptor_1d_value_enum(DFTI_PLACEMENT, DFTI_NOT_INPLACE);
@@ -678,19 +697,19 @@ int @REALIN@_@COMPLEXOUT@_mkl_@mode@_out(
 
     if (input_number_of_transforms > 1) {
         status = __set_descriptor_1d_value_long(
-	    DFTI_NUMBER_OF_TRANSFORMS, input_number_of_transforms);
+            DFTI_NUMBER_OF_TRANSFORMS, input_number_of_transforms);
         if (status != 0) goto failed;
 
-	status = __set_descriptor_1d_value_long(DFTI_INPUT_DISTANCE, input_distance);
+        status = __set_descriptor_1d_value_long(DFTI_INPUT_DISTANCE, input_distance);
         if (status != 0) goto failed;
 
-	status = __set_descriptor_1d_value_long(
-	    DFTI_OUTPUT_DISTANCE, output_distance);
+        status = __set_descriptor_1d_value_long(
+            DFTI_OUTPUT_DISTANCE, output_distance);
         if (status != 0) goto failed;
     }
     else {
         status = __set_descriptor_1d_value_long(
-	    DFTI_NUMBER_OF_TRANSFORMS, input_number_of_transforms);
+            DFTI_NUMBER_OF_TRANSFORMS, input_number_of_transforms);
         if (status != 0) goto failed;
     }
 
@@ -698,116 +717,116 @@ int @REALIN@_@COMPLEXOUT@_mkl_@mode@_out(
     if (status != 0) goto failed;
 
     if (single_DftiCompute){
-	status = __cached_notinplace_DftiComputeForward_@MKL_IN_TYPE@_@MKL_OUT_TYPE@(
-	    xin_data, xout_data);
-	if (status != 0) goto failed;
+        status = __cached_notinplace_DftiComputeForward_@MKL_IN_TYPE@_@MKL_OUT_TYPE@(
+            xin_data, xout_data);
+        if (status != 0) goto failed;
     } else {
-	multi_iter_masked_t *mit;
-	int *mask;
-	int i;
+        multi_iter_masked_t *mit;
+        int *mask;
+        int i;
 
-	mask = (int *) mkl_malloc((xin_rank-1)*sizeof(int), 64);
+        mask = (int *) mkl_malloc((xin_rank-1)*sizeof(int), 64);
 
-	for(i = 0; i < axis; i++) mask[i] = i;
-	for(i = axis + 1; i < xin_rank; i++) mask[i-1] = i;
+        for(i = 0; i < axis; i++) mask[i] = i;
+        for(i = axis + 1; i < xin_rank; i++) mask[i-1] = i;
 
-	mit = multi_iter_masked_new(xin_shape, xin_rank, mask, xin_rank - 1);
+        mit = multi_iter_masked_new(xin_shape, xin_rank, mask, xin_rank - 1);
 
-	while(!MultiIter_Done(mit)) {
-	    char *tmp1, *tmp2;
+        while(!MultiIter_Done(mit)) {
+            char *tmp1, *tmp2;
 
-	    for(tmp1 = (char *) xin_data,
-		tmp2 = (char *) xout_data,
-		i = 0; i < xin_rank; i++) {
-		tmp1 += xin_strides[i] * MultiIter_IndexElem(mit, i);
-		tmp2 += xout_strides[i] * MultiIter_IndexElem(mit, i);
-	    }
+            for(tmp1 = (char *) xin_data,
+                tmp2 = (char *) xout_data,
+                i = 0; i < xin_rank; i++) {
+                tmp1 += xin_strides[i] * MultiIter_IndexElem(mit, i);
+                tmp2 += xout_strides[i] * MultiIter_IndexElem(mit, i);
+            }
 
-	    status = __cached_notinplace_DftiComputeForward_@MKL_IN_TYPE@_@MKL_OUT_TYPE@( 
-		(@MKL_IN_TYPE@*) tmp1, (@MKL_OUT_TYPE@*) tmp2 );
-	    if (status != 0) break;
+            status = __cached_notinplace_DftiComputeForward_@MKL_IN_TYPE@_@MKL_OUT_TYPE@( 
+                (@MKL_IN_TYPE@*) tmp1, (@MKL_OUT_TYPE@*) tmp2 );
+            if (status != 0) break;
 
-	    if (multi_iter_masked_next(mit))
-		break;
-	}
+            if (multi_iter_masked_next(mit))
+                break;
+        }
 
 
-	multi_iter_masked_free(mit);
-	mkl_free(mask);
+        multi_iter_masked_free(mit);
+        mkl_free(mask);
 
-	if (status != 0) goto failed;
+        if (status != 0) goto failed;
     }
 
 
     /* fill the rest of the output array */
     /* TODO: optimize for 1D and 2D */
     if (all_harmonics) {
-	npy_intp n_last = xout_shape[axis];
-	npy_intp nh_last = (n_last/2) + 1;
+        npy_intp n_last = xout_shape[axis];
+        npy_intp nh_last = (n_last/2) + 1;
 
         if (xout_rank == 1) {
             npy_intp it, it_max = (n_last > 2) ? n_last: nh_last;
-	    npy_intp s = xout_strides[0] / xout_itemsize;
+            npy_intp s = xout_strides[0] / xout_itemsize;
 
             /* TODO: parallelize with openmp ? */
-	    for(it = nh_last; it < it_max; it++) {
+            for(it = nh_last; it < it_max; it++) {
                 @MKL_OUT_TYPE@
-		    *src = xout_data + (n_last - it)*s,
-		    *dest = xout_data + it*s;
+                    *src = xout_data + (n_last - it)*s,
+                    *dest = xout_data + it*s;
 
                 SET_CONJ(dest, src);
-	    }
+            }
 /*
-	} else if(single_DftiCompute) {
+        } else if(single_DftiCompute) {
 */
-	} else {
-	    multi_iter_t *mit;
-	    npy_intp *half_shape;
+        } else {
+            multi_iter_t *mit;
+            npy_intp *half_shape;
 
-	    half_shape = (npy_intp *) mkl_malloc(xout_rank * sizeof(npy_intp), 64);
+            half_shape = (npy_intp *) mkl_malloc(xout_rank * sizeof(npy_intp), 64);
 
-	    memcpy(half_shape, xout_shape, xout_rank * sizeof(npy_intp));
-	    half_shape[axis] = (n_last > 2) ? n_last - nh_last: 0;
+            memcpy(half_shape, xout_shape, xout_rank * sizeof(npy_intp));
+            half_shape[axis] = (n_last > 2) ? n_last - nh_last: 0;
 
-	    mit = multi_iter_new(half_shape, xout_rank);
+            mit = multi_iter_new(half_shape, xout_rank);
 
-	    while(!MultiIter_Done(mit)) {
-	        char *tmp1, *tmp2;
-		int i;
-	        @MKL_OUT_TYPE@ *dest, *src;
-	        /* npy_intp k_last = MultiIter_IndexElem(mit, axis); */
+            while(!MultiIter_Done(mit)) {
+                char *tmp1, *tmp2;
+                int i;
+                @MKL_OUT_TYPE@ *dest, *src;
+                /* npy_intp k_last = MultiIter_IndexElem(mit, axis); */
 
-	        for(tmp1 = (char *) xout_data, tmp2 = (char *) xout_data,
-		    i = 0; i < xout_rank; i++) {
-		    npy_intp si = xout_strides[i],
-		             ni = xout_shape[i],
-		             src_ki = MultiIter_IndexElem(mit, i),
-		             dest_ki;
+                for(tmp1 = (char *) xout_data, tmp2 = (char *) xout_data,
+                    i = 0; i < xout_rank; i++) {
+                    npy_intp si = xout_strides[i],
+                             ni = xout_shape[i],
+                             src_ki = MultiIter_IndexElem(mit, i),
+                             dest_ki;
 
-		    dest_ki = src_ki;
-		    if (i == axis) {
-		        dest_ki += nh_last;
-		        assert(dest_ki > 0);
-		        assert(dest_ki < ni);
-		        src_ki = ni - dest_ki;
+                    dest_ki = src_ki;
+                    if (i == axis) {
+                        dest_ki += nh_last;
+                        assert(dest_ki > 0);
+                        assert(dest_ki < ni);
+                        src_ki = ni - dest_ki;
                     }
 
-		    tmp1 += si * dest_ki;
-		    tmp2 += si * src_ki;
-	        }
-	        dest = (@MKL_OUT_TYPE@*) tmp1;
-	        src  = (@MKL_OUT_TYPE@*) tmp2;
+                    tmp1 += si * dest_ki;
+                    tmp2 += si * src_ki;
+                }
+                dest = (@MKL_OUT_TYPE@*) tmp1;
+                src  = (@MKL_OUT_TYPE@*) tmp2;
 
                 SET_CONJ(dest, src);
 
-	        if (multi_iter_next(mit))
-		    break;
-	    }
+                if (multi_iter_next(mit))
+                    break;
+            }
 
 
-	    multi_iter_free(mit);
-	    mkl_free(half_shape);
-	}
+            multi_iter_free(mit);
+            mkl_free(half_shape);
+        }
     }
 
     if (@POST_CONJUGATE@) {
@@ -839,23 +858,23 @@ int @COMPLEXIN@_@COMPLEXOUT@_mkl_@mode@_out(
     PyArrayObject *x_in, npy_intp n, int axis, PyArrayObject *x_out)
 {
     MKL_LONG status = 0, input_distance = 0, output_distance = 0,
-	     input_number_of_transforms = 1;
+             input_number_of_transforms = 1;
     @MKL_TYPE@ *xin_data = 0;
     @MKL_TYPE@ *xout_data = 0;
     /* For 1D transformes strides is a length-2 array */
     MKL_LONG input_strides[2] = {0, 1};
     MKL_LONG output_strides[2] = {0, 1};
     npy_intp *xin_shape = 0, *xin_strides = 0,
-	     *xout_shape = 0, *xout_strides = 0;
+             *xout_shape = 0, *xout_strides = 0;
     int i, xin_rank = 0, xout_rank = 0;
     int single_DftiCompute = NO;
     npy_intp xin_size = 0, xin_itemsize = 0, xout_itemsize = 0, xout_size = 0;
 
 
     get_basic_array_data(x_in, &xin_rank, &xin_shape,
-			 &xin_strides, &xin_itemsize, &xin_size);
+                         &xin_strides, &xin_itemsize, &xin_size);
     get_basic_array_data(x_out, &xout_rank, &xout_shape,
-			 &xout_strides, &xout_itemsize, &xout_size);
+                         &xout_strides, &xout_itemsize, &xout_size);
 
     assert(xout_rank == xin_rank);
 
@@ -867,7 +886,7 @@ int @COMPLEXIN@_@COMPLEXOUT@_mkl_@mode@_out(
     assert(xin_itemsize == sizeof(@MKL_TYPE@));
 
     for(i=0; i < xin_rank; i++)
-	assert( xin_shape[i] >= xout_shape[i]);
+        assert( xin_shape[i] >= xout_shape[i]);
 
     /* output buffer is created in Cython as C_CONTIGUOUS */
     assert(PyArray_ISONESEGMENT(x_out));
@@ -877,116 +896,116 @@ int @COMPLEXIN@_@COMPLEXOUT@_mkl_@mode@_out(
     {
         char *tmp = (char *) xin_data;
         input_strides[1] =
-	    ((@MKL_TYPE@*) (tmp + xin_strides[axis])) - xin_data;
+            ((@MKL_TYPE@*) (tmp + xin_strides[axis])) - xin_data;
 
-	assert(input_strides[0] >= 0);
+        assert(input_strides[0] >= 0);
 
         for(i=0; i < xin_rank; i++) {
             assert( (xin_strides[i] % xin_itemsize) == 0 );
             assert( (xout_strides[i] % xout_itemsize) == 0 );
-	    assert( xout_strides[i] > 0 );
+            assert( xout_strides[i] > 0 );
         }
 
-	/* Compute output strides */
-	tmp = (char *) xout_data;
-	output_strides[1] =
-	    ((@MKL_TYPE@*) (tmp + xout_strides[axis])) - xout_data;
+        /* Compute output strides */
+        tmp = (char *) xout_data;
+        output_strides[1] =
+            ((@MKL_TYPE@*) (tmp + xout_strides[axis])) - xout_data;
     }
 
     single_DftiCompute =
-	compute_strides_and_distances_inout(
-	    x_in,
-	    xin_rank, xin_shape, xin_strides,
-	    xin_itemsize, xin_size, axis,
-	    &input_number_of_transforms,
-	    &input_distance,
-	    xout_shape, xout_strides, xout_itemsize,
-	    &output_distance
-	);
+        compute_strides_and_distances_inout(
+            x_in, x_out,
+            xin_rank, xin_shape, xin_strides,
+            xin_itemsize, xin_size, axis,
+            &input_number_of_transforms,
+            &input_distance,
+            xout_shape, xout_strides, xout_itemsize,
+            &output_distance
+        );
 
     status = __create_descriptor_1d_@DFTI_PRECISION@_DFTI_COMPLEX(
-	_to_mkl_long(n), 1.0, 1.0/n);
+        _to_mkl_long(n), 1.0, 1.0/n);
     if (status != 0) goto failed;
 
     status = __set_descriptor_1d_value_enum(
-	DFTI_COMPLEX_STORAGE, DFTI_COMPLEX_COMPLEX);
+        DFTI_COMPLEX_STORAGE, DFTI_COMPLEX_COMPLEX);
     if (status != 0) goto failed;
 
     status = __set_descriptor_1d_value_longp(
-	DFTI_INPUT_STRIDES, input_strides);
+        DFTI_INPUT_STRIDES, input_strides);
     if (status != 0) goto failed;
 
     status = __set_descriptor_1d_value_enum(
-	DFTI_PLACEMENT, DFTI_NOT_INPLACE);
+        DFTI_PLACEMENT, DFTI_NOT_INPLACE);
     if (status != 0) goto failed;
 
     status = __set_descriptor_1d_value_longp(
-	DFTI_OUTPUT_STRIDES, output_strides);
+        DFTI_OUTPUT_STRIDES, output_strides);
     if (status != 0) goto failed;
 
     if (input_number_of_transforms > 1) {
-	status = __set_descriptor_1d_value_long(
-	    DFTI_NUMBER_OF_TRANSFORMS, input_number_of_transforms);
+        status = __set_descriptor_1d_value_long(
+            DFTI_NUMBER_OF_TRANSFORMS, input_number_of_transforms);
         if (status != 0) goto failed;
 
-	status = __set_descriptor_1d_value_long(
-	    DFTI_INPUT_DISTANCE, input_distance);
+        status = __set_descriptor_1d_value_long(
+            DFTI_INPUT_DISTANCE, input_distance);
         if (status != 0) goto failed;
 
-	status = __set_descriptor_1d_value_long(
-	    DFTI_OUTPUT_DISTANCE, output_distance);
+        status = __set_descriptor_1d_value_long(
+            DFTI_OUTPUT_DISTANCE, output_distance);
         if (status != 0) goto failed;
     }
     else {
-	assert(input_number_of_transforms == 1);
+        assert(input_number_of_transforms == 1);
 
-	status = __set_descriptor_1d_value_long(
-	    DFTI_NUMBER_OF_TRANSFORMS, input_number_of_transforms);
-	if (status != 0) goto failed;
+        status = __set_descriptor_1d_value_long(
+            DFTI_NUMBER_OF_TRANSFORMS, input_number_of_transforms);
+        if (status != 0) goto failed;
     }
 
     status = __commit_descriptor_1d();
     if (status != 0) goto failed;
 
     if (single_DftiCompute){
-	status = __cached_notinplace_@DftiCompute_MODE@_@MKL_TYPE@_@MKL_TYPE@(
-	    xin_data, xout_data);
-	if (status != 0) goto failed;
+        status = __cached_notinplace_@DftiCompute_MODE@_@MKL_TYPE@_@MKL_TYPE@(
+            xin_data, xout_data);
+        if (status != 0) goto failed;
     } else {
-	multi_iter_masked_t *mit;
-	int *mask;
-	int i;
+        multi_iter_masked_t *mit;
+        int *mask;
+        int i;
 
-	mask = (int *) mkl_malloc((xin_rank-1)*sizeof(int), 64);
+        mask = (int *) mkl_malloc((xin_rank-1)*sizeof(int), 64);
 
-	for(i = 0; i < axis; i++) mask[i] = i;
-	for(i = axis + 1; i < xin_rank; i++) mask[i-1] = i;
+        for(i = 0; i < axis; i++) mask[i] = i;
+        for(i = axis + 1; i < xin_rank; i++) mask[i-1] = i;
 
-	mit = multi_iter_masked_new(xin_shape, xin_rank, mask, xin_rank - 1);
+        mit = multi_iter_masked_new(xin_shape, xin_rank, mask, xin_rank - 1);
 
-	while(!MultiIter_Done(mit)) {
-	    char *tmp1, *tmp2;
+        while(!MultiIter_Done(mit)) {
+            char *tmp1, *tmp2;
 
-	    for(tmp1 = (char *) xin_data,
-		tmp2 = (char *) xout_data,
-		i = 0; i < xin_rank; i++) {
-		tmp1 += xin_strides[i] * MultiIter_IndexElem(mit, i);
-		tmp2 += xout_strides[i] * MultiIter_IndexElem(mit, i);
-	    }
+            for(tmp1 = (char *) xin_data,
+                tmp2 = (char *) xout_data,
+                i = 0; i < xin_rank; i++) {
+                tmp1 += xin_strides[i] * MultiIter_IndexElem(mit, i);
+                tmp2 += xout_strides[i] * MultiIter_IndexElem(mit, i);
+            }
 
-	    status = __cached_notinplace_@DftiCompute_MODE@_@MKL_TYPE@_@MKL_TYPE@(
-		(@MKL_TYPE@*) tmp1, (@MKL_TYPE@*) tmp2);
-	    if (status != 0) break;
+            status = __cached_notinplace_@DftiCompute_MODE@_@MKL_TYPE@_@MKL_TYPE@(
+                (@MKL_TYPE@*) tmp1, (@MKL_TYPE@*) tmp2);
+            if (status != 0) break;
 
-	    if (multi_iter_masked_next(mit))
-		break;
-	}
+            if (multi_iter_masked_next(mit))
+                break;
+        }
 
 
-	multi_iter_masked_free(mit);
-	mkl_free(mask);
+        multi_iter_masked_free(mit);
+        mkl_free(mask);
 
-	if (status != 0) goto failed;
+        if (status != 0) goto failed;
     }
 
     status = OK;
@@ -1018,7 +1037,7 @@ int @COMPLEXIN@_@COMPLEXOUT@_mkl_@mode@_out(
 int @name@_mkl_@mode@_in(PyArrayObject* x_inout, npy_intp n, int axis)
 {
     MKL_LONG status = 0, input_distance = 0,
-	     input_number_of_transforms = 1;
+             input_number_of_transforms = 1;
     @MKL_TYPE@ *x_data = 0;
     /* For 1D transformes strides is a length-2 array */
     MKL_LONG input_strides[2] = {0, 1};
@@ -1028,7 +1047,7 @@ int @name@_mkl_@mode@_in(PyArrayObject* x_inout, npy_intp n, int axis)
     npy_intp x_size, x_itemsize;
 
     get_basic_array_data(x_inout, &x_rank, &x_shape,
-			 &x_strides, &x_itemsize, &x_size);
+                         &x_strides, &x_itemsize, &x_size);
 
     assert( x_size > 0 ); /* assert that  */
     assert(0 <= axis && axis < x_rank);
@@ -1043,14 +1062,14 @@ int @name@_mkl_@mode@_in(PyArrayObject* x_inout, npy_intp n, int axis)
         for(i=0; i < x_rank; i++) {
             assert( (x_strides[i] % x_itemsize) == 0 );
         }
-	assert(input_strides[0] >= 0);
+        assert(input_strides[0] >= 0);
     }
 
     single_DftiCompute =
     compute_strides_and_distances(
-	x_inout,
-	x_rank, x_shape, x_strides, x_itemsize, x_size, axis,
-	&input_number_of_transforms, &input_distance);
+        x_inout,
+        x_rank, x_shape, x_strides, x_itemsize, x_size, axis,
+        &input_number_of_transforms, &input_distance);
 
     status = __create_descriptor_1d_@DFTI_PRECISION@_DFTI_REAL(_to_mkl_long(n), 1.0, 1.0/n);
     if (status != 0) goto failed;
@@ -1061,7 +1080,7 @@ int @name@_mkl_@mode@_in(PyArrayObject* x_inout, npy_intp n, int axis)
     if (status != 0) goto failed;
 
     status = __set_descriptor_1d_value_enum(
-	DFTI_CONJUGATE_EVEN_STORAGE, DFTI_COMPLEX_REAL);
+        DFTI_CONJUGATE_EVEN_STORAGE, DFTI_COMPLEX_REAL);
     if (status != 0) goto failed;
 
     status = __set_descriptor_1d_value_enum(DFTI_PACKED_FORMAT, DFTI_PACK_FORMAT);
@@ -1073,53 +1092,53 @@ int @name@_mkl_@mode@_in(PyArrayObject* x_inout, npy_intp n, int axis)
 
     if (input_number_of_transforms > 1) {
         status = __set_descriptor_1d_value_long(
-	    DFTI_NUMBER_OF_TRANSFORMS, input_number_of_transforms);
-	if (status != 0) goto failed;
+            DFTI_NUMBER_OF_TRANSFORMS, input_number_of_transforms);
+        if (status != 0) goto failed;
 
-	status = __set_descriptor_1d_value_long(DFTI_INPUT_DISTANCE, input_distance);
-	if (status != 0) goto failed;
+        status = __set_descriptor_1d_value_long(DFTI_INPUT_DISTANCE, input_distance);
+        if (status != 0) goto failed;
     }
     else { /* it is important to set the number of transforms for cached descriptor */
         status = __set_descriptor_1d_value_long(DFTI_NUMBER_OF_TRANSFORMS,
-						input_number_of_transforms);
-	if (status != 0) goto failed;
+                                                input_number_of_transforms);
+        if (status != 0) goto failed;
     }
 
     status = __commit_descriptor_1d();
     if (status != 0) goto failed;
 
     if (single_DftiCompute){
-	status = __cached_inplace_@DftiCompute_MODE@_@MKL_TYPE@(x_data);
-	if (status != 0) goto failed;
+        status = __cached_inplace_@DftiCompute_MODE@_@MKL_TYPE@(x_data);
+        if (status != 0) goto failed;
     } else {
-	multi_iter_masked_t *mit;
-	int *mask;
-	int i;
+        multi_iter_masked_t *mit;
+        int *mask;
+        int i;
 
-	mask = (int *) mkl_malloc((x_rank-1)*sizeof(int), 64);
+        mask = (int *) mkl_malloc((x_rank-1)*sizeof(int), 64);
 
-	for(i = 0; i < axis; i++) mask[i] = i;
-	for(i = axis + 1; i < x_rank; i++) mask[i-1] = i;
+        for(i = 0; i < axis; i++) mask[i] = i;
+        for(i = axis + 1; i < x_rank; i++) mask[i-1] = i;
 
-	mit = multi_iter_masked_new(x_shape, x_rank, mask, x_rank - 1);
+        mit = multi_iter_masked_new(x_shape, x_rank, mask, x_rank - 1);
 
-	while(!MultiIter_Done(mit)) {
-	    char *tmp;
+        while(!MultiIter_Done(mit)) {
+            char *tmp;
 
-	    for(tmp = (char *) x_data, i = 0; i < x_rank; i++)
-		tmp += x_strides[i] * MultiIter_IndexElem(mit, i);
+            for(tmp = (char *) x_data, i = 0; i < x_rank; i++)
+                tmp += x_strides[i] * MultiIter_IndexElem(mit, i);
 
-	    status = __cached_inplace_@DftiCompute_MODE@_@MKL_TYPE@((@MKL_TYPE@*) tmp);
-	    if (status != 0) break;
+            status = __cached_inplace_@DftiCompute_MODE@_@MKL_TYPE@((@MKL_TYPE@*) tmp);
+            if (status != 0) break;
 
-	    if (multi_iter_masked_next(mit))
-		break;
-	}
+            if (multi_iter_masked_next(mit))
+                break;
+        }
 
-	multi_iter_masked_free(mit);
-	mkl_free(mask);
+        multi_iter_masked_free(mit);
+        mkl_free(mask);
 
-	if (status != 0) goto failed;
+        if (status != 0) goto failed;
     }
 
     return OK;
@@ -1143,23 +1162,23 @@ int
     PyArrayObject* x_in, npy_intp n, int axis, PyArrayObject* x_out)
 {
     MKL_LONG status = 0, input_distance = 0, output_distance = 0,
-	     input_number_of_transforms = 1;
+             input_number_of_transforms = 1;
     @MKL_IN_TYPE@ *xin_data = 0;
     @MKL_OUT_TYPE@ *xout_data = 0;
     /* For 1D transformes strides is a length-2 array */
     MKL_LONG input_strides[2] = {0, 1};
     MKL_LONG output_strides[2] = {0, 1};
     npy_intp *xin_shape = 0, *xin_strides = 0,
-	     *xout_shape = 0, *xout_strides = 0;
+             *xout_shape = 0, *xout_strides = 0;
     int i, xin_rank = 0, xout_rank = 0;
     int single_DftiCompute = NO;
     npy_intp xin_size = 0, xin_itemsize = 0, xout_itemsize = 0, xout_size = 0;
 
 
     get_basic_array_data(x_in, &xin_rank, &xin_shape,
-			 &xin_strides, &xin_itemsize, &xin_size);
+                         &xin_strides, &xin_itemsize, &xin_size);
     get_basic_array_data(x_out, &xout_rank, &xout_shape,
-			 &xout_strides, &xout_itemsize, &xout_size);
+                         &xout_strides, &xout_itemsize, &xout_size);
 
     assert(xout_rank == xin_rank);
 
@@ -1178,116 +1197,116 @@ int
     {
         char *tmp = (char *) xin_data;
         input_strides[1] =
-	    ((@MKL_IN_TYPE@*) (tmp + xin_strides[axis])) - xin_data;
+            ((@MKL_IN_TYPE@*) (tmp + xin_strides[axis])) - xin_data;
 
-	assert(input_strides[0] >= 0);
+        assert(input_strides[0] >= 0);
 
         for(i=0; i < xin_rank; i++) {
             assert( (xin_strides[i] % xin_itemsize) == 0 );
             assert( (xout_strides[i] % xout_itemsize) == 0 );
-	    assert( xout_strides[i] > 0 );
+            assert( xout_strides[i] > 0 );
         }
 
-	/* Compute output strides */
-	tmp = (char *) xout_data;
-	output_strides[1] =
-	    ((@MKL_OUT_TYPE@*) (tmp + xout_strides[axis])) - xout_data;
+        /* Compute output strides */
+        tmp = (char *) xout_data;
+        output_strides[1] =
+            ((@MKL_OUT_TYPE@*) (tmp + xout_strides[axis])) - xout_data;
     }
 
     single_DftiCompute =
-	compute_strides_and_distances_inout(
-	    x_in,
-	    xin_rank, xin_shape, xin_strides,
-	    xin_itemsize, xin_size, axis,
-	    &input_number_of_transforms,
-	    &input_distance,
-	    xout_shape, xout_strides, xout_itemsize,
-	    &output_distance
-	);
+        compute_strides_and_distances_inout(
+            x_in, x_out,
+            xin_rank, xin_shape, xin_strides,
+            xin_itemsize, xin_size, axis,
+            &input_number_of_transforms,
+            &input_distance,
+            xout_shape, xout_strides, xout_itemsize,
+            &output_distance
+        );
 
     status = __create_descriptor_1d_@DFTI_PRECISION@_DFTI_REAL(
-	_to_mkl_long(n), 1.0, 1.0/n);
+        _to_mkl_long(n), 1.0, 1.0/n);
     if (status != 0) goto failed;
 
     status = __set_descriptor_1d_value_enum(
-	DFTI_CONJUGATE_EVEN_STORAGE, DFTI_COMPLEX_COMPLEX);
+        DFTI_CONJUGATE_EVEN_STORAGE, DFTI_COMPLEX_COMPLEX);
     if (status != 0) goto failed;
 
     status = __set_descriptor_1d_value_longp(
-	DFTI_INPUT_STRIDES, input_strides);
+        DFTI_INPUT_STRIDES, input_strides);
     if (status != 0) goto failed;
 
     status = __set_descriptor_1d_value_enum(
-	DFTI_PLACEMENT, DFTI_NOT_INPLACE);
+        DFTI_PLACEMENT, DFTI_NOT_INPLACE);
     if (status != 0) goto failed;
 
     status = __set_descriptor_1d_value_longp(
-	DFTI_OUTPUT_STRIDES, output_strides);
+        DFTI_OUTPUT_STRIDES, output_strides);
     if (status != 0) goto failed;
 
     if (input_number_of_transforms > 1) {
-	status = __set_descriptor_1d_value_long(
-	    DFTI_NUMBER_OF_TRANSFORMS, input_number_of_transforms);
+        status = __set_descriptor_1d_value_long(
+            DFTI_NUMBER_OF_TRANSFORMS, input_number_of_transforms);
         if (status != 0) goto failed;
 
-	status = __set_descriptor_1d_value_long(
-	    DFTI_INPUT_DISTANCE, input_distance);
+        status = __set_descriptor_1d_value_long(
+            DFTI_INPUT_DISTANCE, input_distance);
         if (status != 0) goto failed;
 
-	status = __set_descriptor_1d_value_long(
-	    DFTI_OUTPUT_DISTANCE, output_distance);
+        status = __set_descriptor_1d_value_long(
+            DFTI_OUTPUT_DISTANCE, output_distance);
         if (status != 0) goto failed;
     }
     else {
-	assert(input_number_of_transforms == 1);
+        assert(input_number_of_transforms == 1);
 
-	status = __set_descriptor_1d_value_long(
-	    DFTI_NUMBER_OF_TRANSFORMS, input_number_of_transforms);
-	if (status != 0) goto failed;
+        status = __set_descriptor_1d_value_long(
+            DFTI_NUMBER_OF_TRANSFORMS, input_number_of_transforms);
+        if (status != 0) goto failed;
     }
 
     status = __commit_descriptor_1d();
     if (status != 0) goto failed;
 
     if (single_DftiCompute){
-	status = __cached_notinplace_DftiComputeBackward_@MKL_IN_TYPE@_@MKL_OUT_TYPE@(
-	    xin_data, xout_data);
-	if (status != 0) goto failed;
+        status = __cached_notinplace_DftiComputeBackward_@MKL_IN_TYPE@_@MKL_OUT_TYPE@(
+            xin_data, xout_data);
+        if (status != 0) goto failed;
     } else {
-	multi_iter_masked_t *mit;
-	int *mask;
-	int i;
+        multi_iter_masked_t *mit;
+        int *mask;
+        int i;
 
-	mask = (int *) mkl_malloc((xin_rank-1)*sizeof(int), 64);
+        mask = (int *) mkl_malloc((xin_rank-1)*sizeof(int), 64);
 
-	for(i = 0; i < axis; i++) mask[i] = i;
-	for(i = axis + 1; i < xin_rank; i++) mask[i-1] = i;
+        for(i = 0; i < axis; i++) mask[i] = i;
+        for(i = axis + 1; i < xin_rank; i++) mask[i-1] = i;
 
-	mit = multi_iter_masked_new(xin_shape, xin_rank, mask, xin_rank - 1);
+        mit = multi_iter_masked_new(xin_shape, xin_rank, mask, xin_rank - 1);
 
-	while(!MultiIter_Done(mit)) {
-	    char *tmp1, *tmp2;
+        while(!MultiIter_Done(mit)) {
+            char *tmp1, *tmp2;
 
-	    for(tmp1 = (char *) xin_data,
-		tmp2 = (char *) xout_data,
-		i = 0; i < xin_rank; i++) {
-		tmp1 += xin_strides[i] * MultiIter_IndexElem(mit, i);
-		tmp2 += xout_strides[i] * MultiIter_IndexElem(mit, i);
-	    }
+            for(tmp1 = (char *) xin_data,
+                tmp2 = (char *) xout_data,
+                i = 0; i < xin_rank; i++) {
+                tmp1 += xin_strides[i] * MultiIter_IndexElem(mit, i);
+                tmp2 += xout_strides[i] * MultiIter_IndexElem(mit, i);
+            }
 
-	    status = __cached_notinplace_DftiComputeBackward_@MKL_IN_TYPE@_@MKL_OUT_TYPE@(
-		(@MKL_IN_TYPE@*) tmp1, (@MKL_OUT_TYPE@*) tmp2);
-	    if (status != 0) break;
+            status = __cached_notinplace_DftiComputeBackward_@MKL_IN_TYPE@_@MKL_OUT_TYPE@(
+                (@MKL_IN_TYPE@*) tmp1, (@MKL_OUT_TYPE@*) tmp2);
+            if (status != 0) break;
 
-	    if (multi_iter_masked_next(mit))
-		break;
-	}
+            if (multi_iter_masked_next(mit))
+                break;
+        }
 
 
-	multi_iter_masked_free(mit);
-	mkl_free(mask);
+        multi_iter_masked_free(mit);
+        mkl_free(mask);
 
-	if (status != 0) goto failed;
+        if (status != 0) goto failed;
     }
 
     status = OK;
@@ -1315,23 +1334,23 @@ int @name@_@name@_mkl_@mode@_out(
     PyArrayObject* x_in, npy_intp n, int axis, PyArrayObject *x_out)
 {
     MKL_LONG status = 0, input_distance = 0, output_distance = 0,
-	     input_number_of_transforms = 1;
+             input_number_of_transforms = 1;
     @MKL_TYPE@ *xin_data = 0;
     @MKL_TYPE@ *xout_data = 0;
     /* For 1D transformes strides is a length-2 array */
     MKL_LONG input_strides[2] = {0, 1};
     MKL_LONG output_strides[2] = {0, 1};
     npy_intp *xin_shape = 0, *xin_strides = 0,
-	     *xout_shape = 0, *xout_strides = 0;
+             *xout_shape = 0, *xout_strides = 0;
     int i, xin_rank = 0, xout_rank = 0;
     int single_DftiCompute = NO;
     npy_intp xin_size = 0, xin_itemsize = 0, xout_itemsize = 0, xout_size = 0;
 
 
     get_basic_array_data(x_in, &xin_rank, &xin_shape,
-			 &xin_strides, &xin_itemsize, &xin_size);
+                         &xin_strides, &xin_itemsize, &xin_size);
     get_basic_array_data(x_out, &xout_rank, &xout_shape,
-			 &xout_strides, &xout_itemsize, &xout_size);
+                         &xout_strides, &xout_itemsize, &xout_size);
 
     assert(xout_rank == xin_rank);
 
@@ -1344,7 +1363,7 @@ int @name@_@name@_mkl_@mode@_out(
 
     assert(xout_size <= xin_size);
     for(i=0; i < xin_rank; i++)
-	assert( xin_shape[i] >= xout_shape[i]);
+        assert( xin_shape[i] >= xout_shape[i]);
 
     /* output buffer is created in Cython as C_CONTIGUOUS */
     assert(PyArray_ISONESEGMENT(x_out));
@@ -1354,119 +1373,119 @@ int @name@_@name@_mkl_@mode@_out(
     {
         char *tmp = (char *) xin_data;
         input_strides[1] =
-	    ((@MKL_TYPE@*) (tmp + xin_strides[axis])) - xin_data;
+            ((@MKL_TYPE@*) (tmp + xin_strides[axis])) - xin_data;
 
-	assert(input_strides[0] >= 0);
+        assert(input_strides[0] >= 0);
 
         for(i=0; i < xin_rank; i++) {
             assert( (xin_strides[i] % xin_itemsize) == 0 );
             assert( (xout_strides[i] % xout_itemsize) == 0 );
-	    assert( xout_strides[i] > 0 );
+            assert( xout_strides[i] > 0 );
         }
 
-	/* Compute output strides */
-	tmp = (char *) xout_data;
-	output_strides[1] =
-	    ((@MKL_TYPE@*) (tmp + xout_strides[axis])) - xout_data;
+        /* Compute output strides */
+        tmp = (char *) xout_data;
+        output_strides[1] =
+            ((@MKL_TYPE@*) (tmp + xout_strides[axis])) - xout_data;
     }
 
     single_DftiCompute =
-	compute_strides_and_distances_inout(
-	    x_in,
-	    xin_rank, xin_shape, xin_strides,
-	    xin_itemsize, xin_size, axis,
-	    &input_number_of_transforms,
-	    &input_distance,
-	    xout_shape, xout_strides, xout_itemsize,
-	    &output_distance
-	);
+        compute_strides_and_distances_inout(
+            x_in, x_out,
+            xin_rank, xin_shape, xin_strides,
+            xin_itemsize, xin_size, axis,
+            &input_number_of_transforms,
+            &input_distance,
+            xout_shape, xout_strides, xout_itemsize,
+            &output_distance
+        );
 
     status = __create_descriptor_1d_@DFTI_PRECISION@_DFTI_REAL(
-	_to_mkl_long(n), 1.0, 1.0/n);
+        _to_mkl_long(n), 1.0, 1.0/n);
     if (status != 0) goto failed;
 
     status = __set_descriptor_1d_value_enum(
-	DFTI_CONJUGATE_EVEN_STORAGE, DFTI_COMPLEX_REAL);
+        DFTI_CONJUGATE_EVEN_STORAGE, DFTI_COMPLEX_REAL);
     if (status != 0) goto failed;
 
     status = __set_descriptor_1d_value_enum(DFTI_PACKED_FORMAT, DFTI_PACK_FORMAT);
     if (status != 0) goto failed;
 
     status = __set_descriptor_1d_value_longp(
-	DFTI_INPUT_STRIDES, input_strides);
+        DFTI_INPUT_STRIDES, input_strides);
     if (status != 0) goto failed;
 
     status = __set_descriptor_1d_value_enum(
-	DFTI_PLACEMENT, DFTI_NOT_INPLACE);
+        DFTI_PLACEMENT, DFTI_NOT_INPLACE);
     if (status != 0) goto failed;
 
     status = __set_descriptor_1d_value_longp(
-	DFTI_OUTPUT_STRIDES, output_strides);
+        DFTI_OUTPUT_STRIDES, output_strides);
     if (status != 0) goto failed;
 
     if (input_number_of_transforms > 1) {
-	status = __set_descriptor_1d_value_long(
-	    DFTI_NUMBER_OF_TRANSFORMS, input_number_of_transforms);
+        status = __set_descriptor_1d_value_long(
+            DFTI_NUMBER_OF_TRANSFORMS, input_number_of_transforms);
         if (status != 0) goto failed;
 
-	status = __set_descriptor_1d_value_long(
-	    DFTI_INPUT_DISTANCE, input_distance);
+        status = __set_descriptor_1d_value_long(
+            DFTI_INPUT_DISTANCE, input_distance);
         if (status != 0) goto failed;
 
-	status = __set_descriptor_1d_value_long(
-	    DFTI_OUTPUT_DISTANCE, output_distance);
+        status = __set_descriptor_1d_value_long(
+            DFTI_OUTPUT_DISTANCE, output_distance);
         if (status != 0) goto failed;
     }
     else {
-	assert(input_number_of_transforms == 1);
+        assert(input_number_of_transforms == 1);
 
-	status = __set_descriptor_1d_value_long(
-	    DFTI_NUMBER_OF_TRANSFORMS, input_number_of_transforms);
-	if (status != 0) goto failed;
+        status = __set_descriptor_1d_value_long(
+            DFTI_NUMBER_OF_TRANSFORMS, input_number_of_transforms);
+        if (status != 0) goto failed;
     }
 
     status = __commit_descriptor_1d();
     if (status != 0) goto failed;
 
     if (single_DftiCompute){
-	status = __cached_notinplace_@DftiCompute_MODE@_@MKL_TYPE@_@MKL_TYPE@(
-	    xin_data, xout_data);
-	if (status != 0) goto failed;
+        status = __cached_notinplace_@DftiCompute_MODE@_@MKL_TYPE@_@MKL_TYPE@(
+            xin_data, xout_data);
+        if (status != 0) goto failed;
     } else {
-	multi_iter_masked_t *mit;
-	int *mask;
-	int i;
+        multi_iter_masked_t *mit;
+        int *mask;
+        int i;
 
-	mask = (int *) mkl_malloc((xin_rank-1)*sizeof(int), 64);
+        mask = (int *) mkl_malloc((xin_rank-1)*sizeof(int), 64);
 
-	for(i = 0; i < axis; i++) mask[i] = i;
-	for(i = axis + 1; i < xin_rank; i++) mask[i-1] = i;
+        for(i = 0; i < axis; i++) mask[i] = i;
+        for(i = axis + 1; i < xin_rank; i++) mask[i-1] = i;
 
-	mit = multi_iter_masked_new(xin_shape, xin_rank, mask, xin_rank - 1);
+        mit = multi_iter_masked_new(xin_shape, xin_rank, mask, xin_rank - 1);
 
-	while(!MultiIter_Done(mit)) {
-	    char *tmp1, *tmp2;
+        while(!MultiIter_Done(mit)) {
+            char *tmp1, *tmp2;
 
-	    for(tmp1 = (char *) xin_data,
-		tmp2 = (char *) xout_data,
-		i = 0; i < xin_rank; i++) {
-		tmp1 += xin_strides[i] * MultiIter_IndexElem(mit, i);
-		tmp2 += xout_strides[i] * MultiIter_IndexElem(mit, i);
-	    }
+            for(tmp1 = (char *) xin_data,
+                tmp2 = (char *) xout_data,
+                i = 0; i < xin_rank; i++) {
+                tmp1 += xin_strides[i] * MultiIter_IndexElem(mit, i);
+                tmp2 += xout_strides[i] * MultiIter_IndexElem(mit, i);
+            }
 
-	    status = __cached_notinplace_@DftiCompute_MODE@_@MKL_TYPE@_@MKL_TYPE@(
-		(@MKL_TYPE@*) tmp1, (@MKL_TYPE@*) tmp2);
-	    if (status != 0) break;
+            status = __cached_notinplace_@DftiCompute_MODE@_@MKL_TYPE@_@MKL_TYPE@(
+                (@MKL_TYPE@*) tmp1, (@MKL_TYPE@*) tmp2);
+            if (status != 0) break;
 
-	    if (multi_iter_masked_next(mit))
-		break;
-	}
+            if (multi_iter_masked_next(mit))
+                break;
+        }
 
 
-	multi_iter_masked_free(mit);
-	mkl_free(mask);
+        multi_iter_masked_free(mit);
+        mkl_free(mask);
 
-	if (status != 0) goto failed;
+        if (status != 0) goto failed;
     }
 
     status = OK;
@@ -1504,40 +1523,40 @@ int
     npy_intp x_size, x_itemsize;
 
     get_basic_array_data(x_inout, &x_rank, &x_shape,
-			 &x_strides, &x_itemsize, &x_size);
+                         &x_strides, &x_itemsize, &x_size);
 
 
     assert(x_size > 0);
     assert(x_itemsize == sizeof(@MKL_IN_TYPE@));
 
     if (x_rank == 1) {
-	status =
-	    DftiCreateDescriptor(
-		&hand,
-		@dfti_dom@,
-		DFTI_COMPLEX,
-		x_rank,
-		_to_mkl_long(x_shape[0])
-		);
+        status =
+            DftiCreateDescriptor(
+                &hand,
+                @dfti_dom@,
+                DFTI_COMPLEX,
+                x_rank,
+                _to_mkl_long(x_shape[0])
+                );
     } else {
-	if(NPY_LIKELY(sizeof(MKL_LONG) == sizeof(npy_intp))) {
-	    x_shape_mkl = (MKL_LONG*)x_shape;
-	} else {
-	    // TODO: should rather use alloca or something optimized for small allocations
-	    x_shape_mkl = (MKL_LONG *) mkl_malloc(x_rank*sizeof(MKL_LONG), 64);
-	    if (!x_shape_mkl) goto cleanup;
-	    for(i = 0; i < x_rank; i++)
-		x_shape_mkl[i] = _to_mkl_long(x_shape[i]);
-	}
+        if(NPY_LIKELY(sizeof(MKL_LONG) == sizeof(npy_intp))) {
+            x_shape_mkl = (MKL_LONG*)x_shape;
+        } else {
+            // TODO: should rather use alloca or something optimized for small allocations
+            x_shape_mkl = (MKL_LONG *) mkl_malloc(x_rank*sizeof(MKL_LONG), 64);
+            if (!x_shape_mkl) goto cleanup;
+            for(i = 0; i < x_rank; i++)
+                x_shape_mkl[i] = _to_mkl_long(x_shape[i]);
+        }
 
-	status =
-	    DftiCreateDescriptor(
-		&hand,
-		@dfti_dom@,
-		DFTI_COMPLEX,
-		x_rank,
-		x_shape_mkl
-		);
+        status =
+            DftiCreateDescriptor(
+                &hand,
+                @dfti_dom@,
+                DFTI_COMPLEX,
+                x_rank,
+                x_shape_mkl
+                );
     }
     if (0 != status) goto cleanup;
 
@@ -1552,8 +1571,8 @@ int
 
     input_strides[0] = 0;
     for(i = 0; i < x_rank; i++) {
-	assert( x_strides[i] % x_itemsize == 0 );
-	input_strides[i + 1] = _to_mkl_long (x_strides[i] / x_itemsize);
+        assert( x_strides[i] % x_itemsize == 0 );
+        input_strides[i + 1] = _to_mkl_long (x_strides[i] / x_itemsize);
     }
 
     status = DftiSetValue(hand, DFTI_PLACEMENT, DFTI_INPLACE);
@@ -1570,7 +1589,7 @@ int
     Py_BEGIN_ALLOW_THREADS
     status = DftiCommitDescriptor(hand);
     if (0 == status) {
-	status = @DftiCompute_MODE@(hand, x_data);
+        status = @DftiCompute_MODE@(hand, x_data);
     }
     Py_END_ALLOW_THREADS
     if (0 != status) goto cleanup;
@@ -1609,9 +1628,9 @@ int
     npy_intp xin_size, xout_size, xin_itemsize, xout_itemsize;
 
     get_basic_array_data(x_in, &xin_rank, &xin_shape,
-			 &xin_strides, &xin_itemsize, &xin_size);
+                         &xin_strides, &xin_itemsize, &xin_size);
     get_basic_array_data(x_out, &xout_rank, &xout_shape,
-			 &xout_strides, &xout_itemsize, &xout_size);
+                         &xout_strides, &xout_itemsize, &xout_size);
 
 
     assert(xin_size > 0);
@@ -1621,33 +1640,33 @@ int
     assert(xin_rank == xout_rank);
 
     if (xin_rank == 1) {
-	status =
-	    DftiCreateDescriptor(
-		&hand,
-		@dfti_dom@,
-		DFTI_COMPLEX,
-		1,
-		_to_mkl_long(xin_shape[0])
-		);
+        status =
+            DftiCreateDescriptor(
+                &hand,
+                @dfti_dom@,
+                DFTI_COMPLEX,
+                1,
+                _to_mkl_long(xin_shape[0])
+                );
     } else {
-	if(NPY_LIKELY(sizeof(MKL_LONG) == sizeof(npy_intp))) {
-	    xin_shape_mkl = (MKL_LONG*) xin_shape;
-	} else {
-	    // TODO: should rather use alloca or something optimized for small allocations
-	    xin_shape_mkl = (MKL_LONG *) mkl_malloc(xin_rank * sizeof(MKL_LONG), 64);
-	    if (!xin_shape_mkl) goto cleanup;
-	    for(i = 0; i < xin_rank; i++)
-		xin_shape_mkl[i] = _to_mkl_long(xin_shape[i]);
-	}
+        if(NPY_LIKELY(sizeof(MKL_LONG) == sizeof(npy_intp))) {
+            xin_shape_mkl = (MKL_LONG*) xin_shape;
+        } else {
+            // TODO: should rather use alloca or something optimized for small allocations
+            xin_shape_mkl = (MKL_LONG *) mkl_malloc(xin_rank * sizeof(MKL_LONG), 64);
+            if (!xin_shape_mkl) goto cleanup;
+            for(i = 0; i < xin_rank; i++)
+                xin_shape_mkl[i] = _to_mkl_long(xin_shape[i]);
+        }
 
-	status =
-	    DftiCreateDescriptor(
-		&hand,
-		@dfti_dom@,
-		DFTI_COMPLEX,
-		xin_rank,
-		xin_shape_mkl
-		);
+        status =
+            DftiCreateDescriptor(
+                &hand,
+                @dfti_dom@,
+                DFTI_COMPLEX,
+                xin_rank,
+                xin_shape_mkl
+                );
     }
     if (0 != status) goto cleanup;
 
@@ -1666,11 +1685,11 @@ int
     input_strides[0] = 0;
     output_strides[0] = 0;
     for(i = 0; i < xin_rank; i++) {
-	assert( xin_strides[i] % xin_itemsize == 0 );
-	assert( xout_strides[i] % xout_itemsize == 0 );
+        assert( xin_strides[i] % xin_itemsize == 0 );
+        assert( xout_strides[i] % xout_itemsize == 0 );
 
-	input_strides[i + 1] = _to_mkl_long (xin_strides[i] / xin_itemsize);
-	output_strides[i + 1] = _to_mkl_long (xout_strides[i] / xout_itemsize);
+        input_strides[i + 1] = _to_mkl_long (xin_strides[i] / xin_itemsize);
+        output_strides[i + 1] = _to_mkl_long (xout_strides[i] / xout_itemsize);
     }
 
     status = DftiSetValue(hand, DFTI_PLACEMENT, DFTI_NOT_INPLACE);
@@ -1738,9 +1757,9 @@ int
     npy_intp xin_size, xout_size, xin_itemsize, xout_itemsize;
 
     get_basic_array_data(x_in, &xin_rank, &xin_shape,
-			 &xin_strides, &xin_itemsize, &xin_size);
+                         &xin_strides, &xin_itemsize, &xin_size);
     get_basic_array_data(x_out, &xout_rank, &xout_shape,
-			 &xout_strides, &xout_itemsize, &xout_size);
+                         &xout_strides, &xout_itemsize, &xout_size);
 
 
     assert(xin_size > 0);
@@ -1750,33 +1769,33 @@ int
     assert(xin_rank == xout_rank);
 
     if (xin_rank == 1) {
-	status =
-	    DftiCreateDescriptor(
-		&hand,
-		@dfti_dom@,
-		DFTI_REAL,
-		1,
-		_to_mkl_long(xin_shape[0])
-		);
+        status =
+            DftiCreateDescriptor(
+                &hand,
+                @dfti_dom@,
+                DFTI_REAL,
+                1,
+                _to_mkl_long(xin_shape[0])
+                );
     } else {
-	if(NPY_LIKELY(sizeof(MKL_LONG) == sizeof(npy_intp))) {
-	    xin_shape_mkl = (MKL_LONG*) xin_shape;
-	} else {
-	    /* TODO: should rather use alloca or something optimized for small allocations */
-	    xin_shape_mkl = (MKL_LONG *) mkl_malloc(xin_rank * sizeof(MKL_LONG), 64);
-	    if (!xin_shape_mkl) goto cleanup;
-	    for(i = 0; i < xin_rank; i++)
-		xin_shape_mkl[i] = _to_mkl_long(xin_shape[i]);
-	}
+        if(NPY_LIKELY(sizeof(MKL_LONG) == sizeof(npy_intp))) {
+            xin_shape_mkl = (MKL_LONG*) xin_shape;
+        } else {
+            /* TODO: should rather use alloca or something optimized for small allocations */
+            xin_shape_mkl = (MKL_LONG *) mkl_malloc(xin_rank * sizeof(MKL_LONG), 64);
+            if (!xin_shape_mkl) goto cleanup;
+            for(i = 0; i < xin_rank; i++)
+                xin_shape_mkl[i] = _to_mkl_long(xin_shape[i]);
+        }
 
-	status =
-	    DftiCreateDescriptor(
-		&hand,
-		@dfti_dom@,
-		DFTI_REAL,
-		xin_rank,
-		xin_shape_mkl
-		);
+        status =
+            DftiCreateDescriptor(
+                &hand,
+                @dfti_dom@,
+                DFTI_REAL,
+                xin_rank,
+                xin_shape_mkl
+                );
     }
     if (0 != status) goto cleanup;
 
@@ -1795,11 +1814,11 @@ int
     input_strides[0] = 0;
     output_strides[0] = 0;
     for(i = 0; i < xin_rank; i++) {
-	assert( xin_strides[i] % xin_itemsize == 0 );
-	assert( xout_strides[i] % xout_itemsize == 0 );
+        assert( xin_strides[i] % xin_itemsize == 0 );
+        assert( xout_strides[i] % xout_itemsize == 0 );
 
-	input_strides[i + 1] = _to_mkl_long (xin_strides[i] / xin_itemsize);
-	output_strides[i + 1] = _to_mkl_long (xout_strides[i] / xout_itemsize);
+        input_strides[i + 1] = _to_mkl_long (xin_strides[i] / xin_itemsize);
+        output_strides[i + 1] = _to_mkl_long (xout_strides[i] / xout_itemsize);
     }
 
     status = DftiSetValue(hand, DFTI_PLACEMENT, DFTI_NOT_INPLACE);
@@ -1827,52 +1846,52 @@ int
 
     /* copy conjugate even harmonics */
     {
-	multi_iter_t *mit;
-	npy_intp *half_shape;
-	npy_intp n_last, nh_last;
-	int i, last_idx = xout_rank - 1;
+        multi_iter_t *mit;
+        npy_intp *half_shape;
+        npy_intp n_last, nh_last;
+        int i, last_idx = xout_rank - 1;
 
-	half_shape = (npy_intp *) mkl_malloc(xout_rank * sizeof(npy_intp), 64);
+        half_shape = (npy_intp *) mkl_malloc(xout_rank * sizeof(npy_intp), 64);
 
-	memcpy(half_shape, xout_shape, xout_rank * sizeof(npy_intp));
-	n_last = xout_shape[last_idx];
-	nh_last = (n_last/2) + 1;
-	half_shape[last_idx] = (n_last > 2) ? n_last - nh_last: 0;
+        memcpy(half_shape, xout_shape, xout_rank * sizeof(npy_intp));
+        n_last = xout_shape[last_idx];
+        nh_last = (n_last/2) + 1;
+        half_shape[last_idx] = (n_last > 2) ? n_last - nh_last: 0;
 
-	mit = multi_iter_new(half_shape, xout_rank);
+        mit = multi_iter_new(half_shape, xout_rank);
 
-	while(!MultiIter_Done(mit)) {
-	    char *tmp1, *tmp2;
-	    @MKL_OUT_TYPE@ *dest, *src;
+        while(!MultiIter_Done(mit)) {
+            char *tmp1, *tmp2;
+            @MKL_OUT_TYPE@ *dest, *src;
 
-	    for(tmp1 = (char *) xout_data, tmp2 = (char *) xout_data,
-		i = 0; i < xout_rank; i++) {
-		npy_intp si = xout_strides[i],
-		         ni = xout_shape[i],
-		         src_ki = MultiIter_IndexElem(mit, i),
-		         dest_ki;
+            for(tmp1 = (char *) xout_data, tmp2 = (char *) xout_data,
+                i = 0; i < xout_rank; i++) {
+                npy_intp si = xout_strides[i],
+                         ni = xout_shape[i],
+                         src_ki = MultiIter_IndexElem(mit, i),
+                         dest_ki;
 
-		dest_ki = src_ki;
-		if (i == last_idx) {
-		    dest_ki += nh_last;
+                dest_ki = src_ki;
+                if (i == last_idx) {
+                    dest_ki += nh_last;
                 }
-		assert(dest_ki >= 0);
-		assert(dest_ki < ni);
-		src_ki = (dest_ki) ? ni - dest_ki : dest_ki;
+                assert(dest_ki >= 0);
+                assert(dest_ki < ni);
+                src_ki = (dest_ki) ? ni - dest_ki : dest_ki;
 
-		tmp1 += si * dest_ki;
-		tmp2 += si * src_ki;
-	    }
-	    dest = (@MKL_OUT_TYPE@*) tmp1;
-	    src  = (@MKL_OUT_TYPE@*) tmp2;
+                tmp1 += si * dest_ki;
+                tmp2 += si * src_ki;
+            }
+            dest = (@MKL_OUT_TYPE@*) tmp1;
+            src  = (@MKL_OUT_TYPE@*) tmp2;
 
-	    /* is there a nicer way to complex conjugate ? */
+            /* is there a nicer way to complex conjugate ? */
             dest->real = src->real;
             dest->imag = -src->imag;
 
-	    if (multi_iter_next(mit))
-		break;
-	}
+            if (multi_iter_next(mit))
+                break;
+        }
     }
 
     if (@POST_CONJUGATE@) {

--- a/mkl_fft/tests/test_fft1d.py
+++ b/mkl_fft/tests/test_fft1d.py
@@ -303,6 +303,28 @@ class Test_mklfft_rank3(TestCase):
             f2 = mkl_fft.fft(f1, axis = ax)
             assert_allclose(f2, x, atol=2e-15)
 
+
+    def test_array5(self):
+        """Inputs with zero strides are handled correctly"""
+        z = self.az3
+        z1 = z[np.newaxis]
+        f1 = mkl_fft.fft(z1, axis=-1)
+        f2 = mkl_fft.fft(z1.reshape(z1.shape), axis=-1)
+        assert_allclose(f1, f2, atol=2e-15)
+        z1 = z[:, np.newaxis]
+        f1 = mkl_fft.fft(z1, axis=-1)
+        f2 = mkl_fft.fft(z1.reshape(z1.shape), axis=-1)
+        assert_allclose(f1, f2, atol=2e-15)
+        z1 = z[:, :, np.newaxis]
+        f1 = mkl_fft.fft(z1, axis=-1)
+        f2 = mkl_fft.fft(z1.reshape(z1.shape), axis=-1)
+        assert_allclose(f1, f2, atol=2e-15)
+        z1 = z[:, :, :, np.newaxis]
+        f1 = mkl_fft.fft(z1, axis=-1)
+        f2 = mkl_fft.fft(z1.reshape(z1.shape), axis=-1)
+        assert_allclose(f1, f2, atol=2e-15)
+
+
 class Test_mklfft_rfft(TestCase):
     def setUp(self):
         rnd.seed(1234567)


### PR DESCRIPTION
Fixes #21. 

When computing parameters for multiple equidistant datasets call to MKL's FFT functions,
during computation of distances between datasets there was an implicit assumption that
strides are all positive.

The code was caught off-guards for arrays with a zero stride, associated with a
unit shape, like one formed by `a[np.newaxis]`.

Added a test. Test checks that fft result is the same for ar, which has unit shape elements and zero strides, as it is for `ar.reshape(ar.shape)`, where all elements of strides vector are populated with actual distances in bytes.