### PR TITLE
Bugfix/remove axes

### DIFF
--- a/mkl_fft/_pydfti.pyx
+++ b/mkl_fft/_pydfti.pyx
@@ -878,7 +878,9 @@ def _remove_axis(s, axes, axis_to_remove):
     a2r = lens + axis_to_remove if axis_to_remove < 0 else axis_to_remove
 
     ss = s[:a2r] + s[a2r+1:]
-    aa = axes_normalized[:a2r] + tuple(ai - 1 for ai in axes_normalized[a2r+1:])
+    pivot = axes_normalized[a2r]
+    aa = tuple(ai if ai < pivot else ai - 1 for ai in axes_normalized[:a2r]) + \
+         tuple(ai if ai < pivot else ai - 1 for ai in axes_normalized[a2r+1:])
     return ss, aa
 
 
@@ -938,7 +940,7 @@ def rfftn_numpy(x, s=None, axes=None):
             ss[-1] = a.shape[la]
             a = _fix_dimensions(a, tuple(ss), axes)
         if len(set(axes)) == len(axes) and len(axes) == a.ndim and len(axes) > 2:
-            ss, aa = _remove_axis(s, axes, la)
+            ss, aa = _remove_axis(s, axes, -1)
             ind = [slice(None,None,1),] * len(s)
             for ii in range(a.shape[la]):
                 ind[la] = ii

--- a/mkl_fft/tests/test_fftnd.py
+++ b/mkl_fft/tests/test_fftnd.py
@@ -119,3 +119,13 @@ class Test_Regressions(TestCase):
                 f1 = mkl_fft.fft(d_ccont, axis=a)
                 f2 = mkl_fft.fft(d_fcont, axis=a)
                 assert_allclose(f1, f2, rtol=r_tol, atol=a_tol)
+
+    def test_rfftn_numpy(self):
+        """Test that rfftn_numpy works as expected"""
+        axes = [(0, 1, 2), (0, 2, 1), (1, 0, 2), (1, 2, 0), (2, 0, 1), (2, 1, 0)]
+        for x in [self.ad, self.af]:
+            for a in axes:
+                r_tol, a_tol = _get_rtol_atol(x)
+                rfft_tr = mkl_fft.rfftn_numpy(np.transpose(x, a))
+                tr_rfft = np.transpose(mkl_fft.rfftn_numpy(x, axes=a), a)
+                assert_allclose(rfft_tr, tr_rfft, rtol=r_tol, atol=a_tol)


### PR DESCRIPTION
Closes #37.

As noted by @Jeitan, the logic in `_remove_axis` was incorrect. 

Now:

```
(b_mkl_fft) [13:28:08 fxsatlin03 mkl_fft]$ ipython
Python 3.6.8 |Intel Corporation| (default, Jan 16 2019, 05:23:57)
Type 'copyright', 'credits' or 'license' for more information
IPython 6.3.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import numpy as np, mkl_fft

In [2]: x = np.random.randn(64, 512, 512)

In [3]: %time z = np.fft.fftpack.rfftn(x, axes=[2, 1, 0])
CPU times: user 3.98 s, sys: 724 ms, total: 4.7 s
Wall time: 1.12 s

In [4]: %time w = mkl_fft.rfftn_numpy(x, axes=[2, 1, 0])
CPU times: user 660 ms, sys: 92 ms, total: 752 ms
Wall time: 47.3 ms

In [5]: np.allclose(w, z)
Out[5]: True
```