### PR TITLE
Fixes NumPy interface bug which did not allow for list/ndarray `axes` or `s` parameters

### DIFF
--- a/mkl_fft/_numpy_fft.py
+++ b/mkl_fft/_numpy_fft.py
@@ -76,8 +76,8 @@ def frwd_sc_1d(n, s):
 
 
 def frwd_sc_nd(s, axes, x_shape):
-    ss = s if s else x_shape
-    if axes:
+    ss = s if s is not None else x_shape
+    if axes is not None:
         nn = prod([ss[ai] for ai in axes])
     else:
         nn = prod(ss)

--- a/mkl_fft/_numpy_fft.py
+++ b/mkl_fft/_numpy_fft.py
@@ -203,7 +203,7 @@ def fft(a, n=None, axis=-1, norm=None):
             mkl_fft.fft,
             (x,),
             {'n':n, 'axis': axis})
-    elif norm is "forward":
+    elif norm == "forward":
         output = trycall(
             mkl_fft.fft,
             (x,),

--- a/mkl_fft/_pydfti.pyx
+++ b/mkl_fft/_pydfti.pyx
@@ -932,7 +932,7 @@ def iter_complementary(x, axes, func, kwargs, result):
     nd = x.ndim
     r = list(range(nd))
     sl = [slice(None, None, None)] * nd
-    if not isinstance(axes, tuple):
+    if not np.iterable(axes):
         axes = (axes,)
     for ai in axes:
         r[ai] = None

--- a/mkl_fft/tests/test_fftnd.py
+++ b/mkl_fft/tests/test_fftnd.py
@@ -114,6 +114,18 @@ class Test_mklfft_matrix(TestCase):
                     rtol=r_tol, atol=a_tol
                 )
 
+    def test_matrix6(self):
+        """fftn with tuple, list and ndarray axes and s"""
+        for ar in [self.md, self.mz, self.mf, self.mc]:
+            d = ar.copy()
+            for norm in ["forward", "backward", "ortho"]:
+                for container in [tuple, list, np.array]:
+                    axes = container(range(d.ndim))
+                    s = container(d.shape)
+                    kwargs = dict(s=s, axes=axes, norm=norm)
+                    r_tol, a_tol = _get_rtol_atol(d)
+                    t = mkl_fft._numpy_fft.fftn(mkl_fft._numpy_fft.ifftn(d, **kwargs), **kwargs)
+                    assert_allclose(d, t, rtol=r_tol, atol=a_tol, err_msg = "failed test for dtype {}, max abs diff: {}".format(d.dtype, np.max(np.abs(d-t))))
 
 
 


### PR DESCRIPTION
## Description
NumPy multidimensional FFTs accept `tuple`, `list` and `np.ndarray` for the `axes` and `s` parameters. Upon substituting a code which ran on standard `numpy` for one running on [`intel-numpy`](https://pypi.org/project/intel-numpy/), I came across a bug where `axes` and `s` struggled to handle anything apart from `tuple`.

This came down to a couple of bugs in `mkl_fft` which are fixed in this PR. In addition, I added a test which should catch these bugs in the future.

Edit: Commit https://github.com/IntelPython/mkl_fft/pull/69/commits/75e9ffd47874392b7498afa826d2ab1bb38f67dd is unrelated to the bug. It's just a code improvement.

## Reproducible examples
To simplify checking, here is a list of behaviors which work/do not work currently. This PR fixes them.

```python
import numpy as np

np.fft.fftn(np.ones((2, 3, 4)), axes=(-1, 0))  # Works
np.fft.fftn(np.ones((2, 3, 4)), axes=[-1, 0])  # Does not work
np.fft.fftn(np.ones((2, 3, 4)), axes=np.array([-1, 0]))  # Does not work
np.fft.fftn(np.ones((2, 3, 4)), axes=(-1, 0), norm="ortho")  # Works
np.fft.fftn(np.ones((2, 3, 4)), axes=[-1, 0], norm="ortho")  # Does not work
np.fft.fftn(np.ones((2, 3, 4)), axes=np.array([-1, 0]), norm="ortho")  # Does not work

np.fft.fftn(np.ones((2, 3, 4)), s=(3, 4, 5))  # Works
np.fft.fftn(np.ones((2, 3, 4)), s=[3, 4, 5])  # Works
np.fft.fftn(np.ones((2, 3, 4)), s=np.array([3, 4, 5]))  # Works

np.fft.fftn(np.ones((2, 3, 4)), s=(4, 5), axes=(-1, 0))  # Works
np.fft.fftn(np.ones((2, 3, 4)), s=[4, 5], axes=[-1, 0])  # Works
np.fft.fftn(np.ones((2, 3, 4)), s=np.array([4, 5]), axes=np.array([-1, 0]))  # Works
np.fft.fftn(np.ones((2, 3, 4)), s=np.array([4, 5]), axes=np.array([-1, 0]), norm="ortho")  # Does not work
```
