### PR TITLE
Support Cython 3.0

### DIFF
--- a/mkl_fft/_pydfti.pyx
+++ b/mkl_fft/_pydfti.pyx
@@ -44,7 +44,7 @@ _tls = threading_local()
 
 cdef const char *capsule_name = "dfti_cache"
 
-cdef void _capsule_destructor(object caps):
+cdef void _capsule_destructor(object caps) noexcept:
     cdef DftiCache *_cache = NULL
     cdef int status = 0
     if (caps is None):


### PR DESCRIPTION
_capsule_destructor can no longer be implicitly converted to PyCapsule_Destructor unless it is marked as not throwing an exception.