### PR TITLE
Changes to support NumPy 2.0

### DIFF
--- a/.github/workflows/build_pip.yaml
+++ b/.github/workflows/build_pip.yaml
@@ -1,4 +1,4 @@
-name: Editable build using pip
+name: Editable build using pip and pre-release NumPy
 
 on: push
 

--- a/.github/workflows/build_pip.yaml
+++ b/.github/workflows/build_pip.yaml
@@ -34,22 +34,21 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           use-mamba: true
-          mamba-version: "*"
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
           channels: conda-forge
           activate-environment: test
           python-version: ${{ matrix.python }}
 
       - name: Install MKL
         run: |
-          conda install -c conda-forge mkl-devel mkl-service --override-channels
-          conda activate test
+          conda install mkl-devel mkl-service
           python -c "import sys; print(sys.executable)"
           which python
           python -c "import mkl; print(mkl.__file__)"
 
       - name: Build conda package
         run: |
-          conda activate test
           pip install --no-cache-dir cython pytest hypothesis
           pip install --no-cache-dir numpy ${{ matrix.use_pre }}
           echo "CONDA_PREFFIX is '${CONDA_PREFIX}'"

--- a/.github/workflows/build_pip.yaml
+++ b/.github/workflows/build_pip.yaml
@@ -12,28 +12,47 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+         shell: bash -el {0}
+
     strategy:
       matrix:
         python: ['3.9', '3.10', '3.11', '3.12']
+        use_pre: ["", "--pre"]
 
     steps:
+      - name: Install jq
+        shell: bash -l {0}
+        run: |
+          sudo apt-get install jq
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Set pkgs_dirs
-        run: |
-          echo "pkgs_dirs: [~/.conda/pkgs]" >> ~/.condarc
-
-      - name: Add conda to system path
-        run: echo $CONDA/bin >> $GITHUB_PATH
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          use-mamba: true
+          mamba-version: "*"
+          channels: conda-forge
+          activate-environment: test
+          python-version: ${{ matrix.python }}
 
       - name: Install MKL
-        run: conda install -c conda-forge mkl-devel mkl-service --override-channels
+        run: |
+          conda install -c conda-forge mkl-devel mkl-service --override-channels
+          conda activate test
+          python -c "import sys; print(sys.executable)"
+          which python
+          python -c "import mkl; print(mkl.__file__)"
 
       - name: Build conda package
         run: |
+          conda activate test
           pip install --no-cache-dir cython pytest hypothesis
-          pip install --no-cache-dir numpy --pre
-          pip install -e . --no-build-isolation
+          pip install --no-cache-dir numpy ${{ matrix.use_pre }}
+          echo "CONDA_PREFFIX is '${CONDA_PREFIX}'"
+          export MKLROOT=${CONDA_PREFIX}
+          pip install -e . --no-build-isolation --verbose --no-deps
           python -m pytest -v mkl_fft/tests

--- a/.github/workflows/build_pip.yaml
+++ b/.github/workflows/build_pip.yaml
@@ -1,0 +1,39 @@
+name: Editable build using pip
+
+on: push
+
+permissions: read-all
+
+env:
+  PACKAGE_NAME: mkl_fft
+  MODULE_NAME: mkl_fft
+  TEST_ENV_NAME: test_mkl_fft
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ['3.9', '3.10', '3.11', '3.12']
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set pkgs_dirs
+        run: |
+          echo "pkgs_dirs: [~/.conda/pkgs]" >> ~/.condarc
+
+      - name: Add conda to system path
+        run: echo $CONDA/bin >> $GITHUB_PATH
+
+      - name: Install MKL
+        run: conda install -c conda-forge mkl-devel mkl-service --override-channels
+
+      - name: Build conda package
+        run: |
+          pip install --no-cache-dir cython pytest hypothesis
+          pip install --no-cache-dir numpy --pre
+          pip install -e . --no-build-isolation
+          python -m pytest -v mkl_fft/tests

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.10']
+        python: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
         with:
@@ -62,7 +62,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.10']
+        python: ['3.9', '3.10', '3.11', '3.12']
         experimental: [false]
         runner: [ubuntu-latest]
     continue-on-error: ${{ matrix.experimental }}
@@ -124,7 +124,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.10']
+        python: ['3.9', '3.10', '3.11', '3.12']
     env:
       conda-bld: C:\Miniconda\conda-bld\win-64\
     steps:
@@ -165,7 +165,7 @@ jobs:
         shell: cmd /C CALL {0}
     strategy:
       matrix:
-        python: ['3.10']
+        python: ['3.9', '3.10', '3.11', '3.12']
         experimental: [false]
         runner: [windows-latest]
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10']
     steps:
       - uses: actions/checkout@v4
         with:
@@ -62,7 +62,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10']
         experimental: [false]
         runner: [ubuntu-latest]
     continue-on-error: ${{ matrix.experimental }}
@@ -124,7 +124,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10']
     env:
       conda-bld: C:\Miniconda\conda-bld\win-64\
     steps:
@@ -165,7 +165,7 @@ jobs:
         shell: cmd /C CALL {0}
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10']
         experimental: [false]
         runner: [windows-2019]
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -120,7 +120,7 @@ jobs:
           pytest -v --pyargs $MODULE_NAME
 
   build_windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     strategy:
       matrix:
@@ -167,7 +167,7 @@ jobs:
       matrix:
         python: ['3.9', '3.10', '3.11', '3.12']
         experimental: [false]
-        runner: [windows-latest]
+        runner: [windows-2019]
     continue-on-error: ${{ matrix.experimental }}
     env:
       workdir: '${{ github.workspace }}'

--- a/mkl_fft/_float_utils.py
+++ b/mkl_fft/_float_utils.py
@@ -59,7 +59,7 @@ def __downcast_float128_array(x):
         xdt = x.dtype
         if xdt == np.longdouble and not xdt == np.float64:
             return np.asarray(x, dtype=np.float64)
-        elif xdt == np.longcomplex and not xdt == np.complex_:
+        elif xdt == np.clongdouble and not xdt == np.complex_:
             return np.asarray(x, dtype=np.complex_)
     if not isinstance(x, np.ndarray):
         __x = np.asarray(x)

--- a/mkl_fft/_numpy_fft.py
+++ b/mkl_fft/_numpy_fft.py
@@ -56,7 +56,7 @@ behavior.)
 __all__ = ['fft', 'ifft', 'rfft', 'irfft', 'hfft', 'ihfft', 'rfftn',
            'irfftn', 'rfft2', 'irfft2', 'fft2', 'ifft2', 'fftn', 'ifftn']
 
-from numpy.core import (array, asarray, asanyarray, shape, conjugate, take, sqrt, prod)
+from numpy import (array, asarray, asanyarray, shape, conjugate, take, sqrt, prod)
 
 import numpy
 from . import _pydfti as mkl_fft

--- a/mkl_fft/_pydfti.pyx
+++ b/mkl_fft/_pydfti.pyx
@@ -29,7 +29,10 @@
 # imports
 import sys
 import numpy as np
-from numpy.core._multiarray_tests import internal_overlap
+if np.lib.NumpyVersion(np.__version__) >= "2.0.0a0":
+    from numpy._core._multiarray_tests import internal_overlap
+else:
+    from numpy.core._multiarray_tests import internal_overlap
 from threading import local as threading_local
 
 # cimports
@@ -133,11 +136,6 @@ cdef extern from "src/mklfft.h":
     int double_cdouble_mkl_ifftnd_out(cnp.ndarray, cnp.ndarray, double)
     char * mkl_dfti_error(int)
 
-# Initialize numpy
-cdef int numpy_import_status = cnp.import_array()
-if numpy_import_status < 0:
-    raise ImportError("Failed to import NumPy as dependency of mkl_fft")
-
 
 cdef int _datacopied(cnp.ndarray arr, object orig):
     """
@@ -217,7 +215,7 @@ cdef cnp.ndarray  __process_arguments(object x, object n, object axis,
           cnp.NPY_ELEMENTSTRIDES | cnp.NPY_ENSUREARRAY | cnp.NPY_NOTSWAPPED,
           NULL)
 
-    if <void *> x_arr is NULL:
+    if (<void *> x_arr) is NULL:
         raise ValueError("An input argument x is not an array-like object")
 
     if _datacopied(x_arr, x):

--- a/mkl_fft/_scipy_fft_backend.py
+++ b/mkl_fft/_scipy_fft_backend.py
@@ -28,7 +28,7 @@ from . import _pydfti
 from . import _float_utils
 import mkl
 
-from numpy.core import (take, sqrt, prod)
+from numpy import (take, sqrt, prod)
 import contextvars
 import contextlib
 import operator

--- a/mkl_fft/src/mklfft.c.src
+++ b/mkl_fft/src/mklfft.c.src
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2017-2020, Intel Corporation
+ Copyright (c) 2017-2024, Intel Corporation
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
@@ -25,9 +25,9 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#define NPY_NO_DEPRECATED_API NPY_API_VERSION
-
+#define PY_SSIZE_T_CLEAN
 #include "Python.h"
+#define NO_IMPORT_ARRAY
 #include "numpy/arrayobject.h"
 #include "mklfft.h"
 #include "multi_iter.h"
@@ -81,13 +81,17 @@ static NPY_INLINE void get_basic_array_data(
     npy_intp *x_size)
 {
     npy_intp asize = 0;
+    npy_intp elsz = 0;
+    int x_ndim = 0;
     assert(x != NULL);
 
-    *x_rank = PyArray_NDIM(x);
+    x_ndim = PyArray_NDIM(x);
+    *x_rank = x_ndim;
     *x_shape = PyArray_SHAPE(x);
     *x_strides = PyArray_STRIDES(x);
-    *x_itemsize = PyArray_ITEMSIZE(x);
-    asize = ar_size(*x_shape, *x_rank);
+    elsz = PyArray_ITEMSIZE(x);
+    *x_itemsize = elsz;
+    asize = ar_size(*x_shape, x_ndim);
     *x_size = asize;
 }
 

--- a/mkl_fft/src/mklfft.h
+++ b/mkl_fft/src/mklfft.h
@@ -25,6 +25,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "mkl.h"
+#include "numpy/arrayobject.h"
 
 typedef struct DftiCache {
     DFTI_DESCRIPTOR_HANDLE hand;

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2017-2023, Intel Corporation
+# Copyright (c) 2017-2024, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -49,10 +49,10 @@ License :: OSI Approved
 Programming Language :: C
 Programming Language :: Python
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.7
-Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
+Programming Language :: Python :: 3.11
+Programming Language :: Python :: 3.12
 Programming Language :: Python :: Implementation :: CPython
 Topic :: Software Development
 Topic :: Scientific/Engineering
@@ -104,7 +104,8 @@ def extensions():
             extra_compile_args = [
                 '-DNDEBUG',
                 # '-ggdb', '-O0', '-Wall', '-Wextra', '-DDEBUG',
-            ]
+            ],
+            define_macros=[("NPY_NO_DEPRECATED_API", None), ("PY_ARRAY_UNIQUE_SYMBOL", "mkl_fft_ext")]
         )
     ]
 


### PR DESCRIPTION
Changes to support NumPy 2.0

Use np.lib.NumpyVersion to account for change in namespace of some functions. Replaced import from numpy.core with import from numpy main namespace, where appropriate.

Replace np.longcomplex with np.clongdouble.

Fixed import of NumPy C-API in _pydfti extension. This follows https://numpy.org/devdocs/reference/c-api/array.html#including-and-importing-the-c-api

Separate translation units, like mklfft.c, need to include arrayobject.h after defining NO_IMPORT_ARRAY preprocessor variable. The extension must be compiled with PY_ARRAY_UNIQUE_SYMBOL set to artibrary value, but same for all translation units.