### PR TITLE
np.longcomplex and np.complex_ are replaced

### DIFF
--- a/mkl_fft/_float_utils.py
+++ b/mkl_fft/_float_utils.py
@@ -59,15 +59,15 @@ def __downcast_float128_array(x):
         xdt = x.dtype
         if xdt == np.longdouble and not xdt == np.float64:
             return np.asarray(x, dtype=np.float64)
-        elif xdt == np.clongdouble and not xdt == np.complex_:
-            return np.asarray(x, dtype=np.complex_)
+        elif xdt == np.clongdouble and not xdt == np.complex128:
+            return np.asarray(x, dtype=np.complex128)
     if not isinstance(x, np.ndarray):
         __x = np.asarray(x)
         xdt = __x.dtype
         if xdt == np.longdouble and not xdt == np.float64:
             return np.asarray(x, dtype=np.float64)
-        elif xdt == np.longcomplex and not xdt == np.complex_:
-            return np.asarray(x, dtype=np.complex_)
+        elif xdt == np.clongdouble and not xdt == np.complex128:
+            return np.asarray(x, dtype=np.complex128)
         return __x
     return x
 


### PR DESCRIPTION
Fixing 

```
FAILED tests/test_interfaces.py::test_numpy_rfftn[float64-ortho] - AttributeError: `np.complex_` was removed in the NumPy 2.0 release. Use `np.complex128` instead.. Did you mean: 'complex64'?
```

![image](https://github.com/IntelPython/mkl_fft/assets/21087696/d90233c7-bf48-4c5d-882b-65074e5ee487)
