### PR TITLE
chore: add Security POlicy doc for OpenSSF scoring

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+Intel is committed to rapidly addressing security vulnerabilities affecting our customers and providing clear guidance on the solution, impact, severity and mitigation. 
+
+## Reporting a Vulnerability
+Please report any security vulnerabilities in this project utilizing the guidelines [here](https://www.intel.com/content/www/us/en/security-center/vulnerability-handling-guidelines.html).


### PR DESCRIPTION
This adds a basic, suggested template for Intel security reporting.
It is the only thing missing for this repo in order for us to hit our OpenSSF scoring goals

Please read the following links:
https://securityscorecards.dev/viewer/?uri=github.com/IntelPython/mkl_fft
https://wiki.ith.intel.com/display/SecTools/OpenSSF+Scorecard+Checks#OpenSSFScorecardChecks-ChecksWithMinimumScoreof0
https://github-vul-scan.intel.com/orgs/IntelPython/repos/dpbench/openssf