### PR TITLE
Reinstate import_array in _pydfti

### DIFF
--- a/.github/workflows/build_pip.yaml
+++ b/.github/workflows/build_pip.yaml
@@ -34,7 +34,6 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           use-mamba: true
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           channels: conda-forge
           activate-environment: test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## ``mkl_fft`` --  a NumPy-based Python interface to Intel (R) MKL FFT functionality
-[![Build Status](https://travis-ci.com/IntelPython/mkl_fft.svg?branch=master)](https://travis-ci.com/IntelPython/mkl_fft)
+[![Conda package](https://github.com/IntelPython/mkl_fft/actions/workflows/conda-package.yml/badge.svg)](https://github.com/IntelPython/mkl_fft/actions/workflows/conda-package.yml)
+[![Editable build using pip and pre-release NumPy](https://github.com/IntelPython/mkl_fft/actions/workflows/build_pip.yaml/badge.svg)](https://github.com/IntelPython/mkl_fft/actions/workflows/build_pip.yaml)
+[![Conda package with conda-forge channel only](https://github.com/IntelPython/mkl_fft/actions/workflows/conda-package-cf.yml/badge.svg)](https://github.com/IntelPython/mkl_fft/actions/workflows/conda-package-cf.yml)
 
 `mkl_fft` started as a part of Intel (R) Distribution for Python* optimizations to NumPy, and is now being released
 as a stand-alone package. It can be installed into conda environment using

--- a/mkl_fft/_pydfti.pyx
+++ b/mkl_fft/_pydfti.pyx
@@ -137,6 +137,12 @@ cdef extern from "src/mklfft.h":
     char * mkl_dfti_error(int)
 
 
+# Initialize numpy
+cdef int numpy_import_status = cnp.import_array()
+if numpy_import_status < 0:
+    raise ImportError("Failed to import NumPy as dependency of mkl_fft")
+
+
 cdef int _datacopied(cnp.ndarray arr, object orig):
     """
     Strict check for `arr` not sharing any data with `original`,


### PR DESCRIPTION
This PR reverts removal of call to `import_array` during initialization of `_pydfti` extension to regain working order when building with Cython <3. 

This PR also updates badges on README file to remove badge for non-existing job and add badges for currently used workflows.