### PR TITLE
update wokflow

### DIFF
--- a/.github/workflows/conda-package-cf.yml
+++ b/.github/workflows/conda-package-cf.yml
@@ -39,10 +39,10 @@ jobs:
         run: echo $CONDA/bin >> $GITHUB_PATH
       - name: Install conda-build
         run: conda install conda-build
-      - name: Build conda package with NumPy 2
+      - name: Build conda package with NumPy 2.0
         run: |
           CHANNELS="-c conda-forge --override-channels"
-          VERSIONS="--python ${{ matrix.python }} --numpy 2"
+          VERSIONS="--python ${{ matrix.python }} --numpy 2.0"
           TEST="--no-test"
 
           conda build \
@@ -54,7 +54,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python }}
-          path: /usr/share/miniconda/conda-bld/linux-64/${{ env.PACKAGE_NAME }}-*.tar.bz2
+          path: /usr/share/miniconda/conda-bld/linux-64/${{ env.PACKAGE_NAME }}-*.conda
 
   test:
     needs: build
@@ -82,7 +82,7 @@ jobs:
       - name: Create conda channel
         run: |
           mkdir -p $GITHUB_WORKSPACE/channel/linux-64
-          mv ${PACKAGE_NAME}-*.tar.bz2 $GITHUB_WORKSPACE/channel/linux-64
+          mv ${PACKAGE_NAME}-*.conda $GITHUB_WORKSPACE/channel/linux-64
           conda index $GITHUB_WORKSPACE/channel
           # Test channel
           conda search $PACKAGE_NAME -c $GITHUB_WORKSPACE/channel --override-channels
@@ -137,9 +137,7 @@ jobs:
           activate-environment: build
           python-version: ${{ matrix.python }}
           channels: conda-forge,nodefaults
-
-      - name: Remove defaults channel
-        run: conda config --remove channels defaults
+          conda-remove-defaults: 'true'
 
       - name: Install conda-build
         run: conda install -n base conda-build
@@ -159,7 +157,7 @@ jobs:
       - name: Build conda package with NumPy 2.0
         run: |
           conda activate
-          conda build --no-test --python ${{ matrix.python }} --numpy 2 -c conda-forge --override-channels conda-recipe-cf
+          conda build --no-test --python ${{ matrix.python }} --numpy 2.0 -c conda-forge --override-channels conda-recipe-cf
 
       - name: Store conda paths as envs
         shell: bash -l {0}
@@ -170,7 +168,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python }}
-          path: ${{ env.CONDA_BLD }}${{ env.PACKAGE_NAME }}-*.tar.bz2
+          path: ${{ env.CONDA_BLD }}${{ env.PACKAGE_NAME }}-*.conda
 
   test_windows:
     needs: build_windows
@@ -201,9 +199,7 @@ jobs:
           activate-environment: ${{ env.TEST_ENV_NAME }}
           python-version: ${{ matrix.python }}
           channels: conda-forge
-
-      - name: Remove defaults channel
-        run: conda config --remove channels defaults
+          conda-remove-defaults: 'true'
 
       - name: Create conda channel with the artifact bit
         shell: cmd /C CALL {0}
@@ -211,7 +207,7 @@ jobs:
           echo ${{ env.workdir }}
           mkdir ${{ env.workdir }}\channel\
           mkdir ${{ env.workdir }}\channel\win-64
-          move ${{ env.PACKAGE_NAME }}-*.tar.bz2 ${{ env.workdir }}\channel\win-64
+          move ${{ env.PACKAGE_NAME }}-*.conda ${{ env.workdir }}\channel\win-64
           dir ${{ env.workdir }}\channel\win-64
 
       - name: Install conda index

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python }}
-          path: /usr/share/miniconda/conda-bld/linux-64/${{ env.PACKAGE_NAME }}-*.tar.bz2
+          path: /usr/share/miniconda/conda-bld/linux-64/${{ env.PACKAGE_NAME }}-*.conda
 
   test:
     needs: build
@@ -81,7 +81,7 @@ jobs:
       - name: Create conda channel
         run: |
           mkdir -p $GITHUB_WORKSPACE/channel/linux-64
-          mv ${PACKAGE_NAME}-*.tar.bz2 $GITHUB_WORKSPACE/channel/linux-64
+          mv ${PACKAGE_NAME}-*.conda $GITHUB_WORKSPACE/channel/linux-64
           conda index $GITHUB_WORKSPACE/channel
           # Test channel
           conda search $PACKAGE_NAME -c $GITHUB_WORKSPACE/channel --override-channels
@@ -135,9 +135,7 @@ jobs:
           activate-environment: build
           python-version: ${{ matrix.python }}
           channels: conda-forge
-
-      - name: Remove defaults channel
-        run: conda config --remove channels defaults
+          conda-remove-defaults: 'true'
 
       - name: Install conda-build
         run: |
@@ -170,7 +168,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python }}
-          path: ${{ env.CONDA_BLD }}${{ env.PACKAGE_NAME }}-*.tar.bz2
+          path: ${{ env.CONDA_BLD }}${{ env.PACKAGE_NAME }}-*.conda
 
   test_windows:
     needs: build_windows
@@ -199,9 +197,7 @@ jobs:
           activate-environment: ${{ env.TEST_ENV_NAME }}
           python-version: ${{ matrix.python }}
           channels: conda-forge
-
-      - name: Remove defaults channel
-        run: conda config --remove channels defaults
+          conda-remove-defaults: 'true'
 
       - name: Create conda channel with the artifact bit
         shell: cmd /C CALL {0}
@@ -209,7 +205,7 @@ jobs:
           echo ${{ env.workdir }}
           mkdir ${{ env.workdir }}\channel\
           mkdir ${{ env.workdir }}\channel\win-64
-          move ${{ env.PACKAGE_NAME }}-*.tar.bz2 ${{ env.workdir }}\channel\win-64
+          move ${{ env.PACKAGE_NAME }}-*.conda ${{ env.workdir }}\channel\win-64
           dir ${{ env.workdir }}\channel\win-64
 
       - name: Install conda index


### PR DESCRIPTION
In this PR, the workflow is updated 1) to account for conda-build (after 25.1.0) moving to producing .conda files instead of tarballs, and 2) to use `conda-remove-defaults` option which enables postprocessing channels list to remove 'defaults' if it was added implicitly to the 'channels' setting.