### PR TITLE
migrate from `setup.py` to `pyproject.toml`

### DIFF
--- a/.github/workflows/build_pip.yaml
+++ b/.github/workflows/build_pip.yaml
@@ -1,6 +1,10 @@
 name: Editable build using pip and pre-release NumPy
 
-on: push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 permissions: read-all
 

--- a/.github/workflows/conda-package-cf.yml
+++ b/.github/workflows/conda-package-cf.yml
@@ -1,6 +1,10 @@
 name: Conda package with conda-forge channel only
 
-on: push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 permissions: read-all
 

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -1,6 +1,10 @@
 name: Conda package
 
-on: push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 permissions: read-all
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+_vendored/__pycache__/
+build/
+mkl_fft.egg-info/
+mkl_fft/__pycache__/
+mkl_fft/_pydfti.c
+mkl_fft/_pydfti.cpython-310-x86_64-linux-gnu.so
+mkl_fft/interfaces/__pycache__/
+mkl_fft/src/mklfft.c
+mkl_fft/tests/__pycache__/

--- a/README.md
+++ b/README.md
@@ -82,5 +82,5 @@ The package also provides `mkl_fft._numpy_fft` and `mkl_fft._scipy_fft` interfac
 
 To build ``mkl_fft`` from sources on Linux:
   - install a recent version of MKL, if necessary;
-  - execute ``source /path/to/mklroot/bin/mklvars.sh intel64`` ;
-  - execute ``pip install .``
+  - execute ``source /path_to_oneapi/mkl/latest/env/vars.sh`` ;
+  - execute ``python -m pip install .``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS"
 ]
-dependencies = ["numpy >=1.16", "mkl", "mkl-service"]
+dependencies = ["numpy >=1.26.4", "mkl", "mkl-service"]
 
 [project.optional-dependencies]
 test = ["pytest"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",
     "Operating System :: Unix",
-    "Operating System :: MacOS"
 ]
 dependencies = ["numpy >=1.26.4", "mkl", "mkl-service"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,78 @@
+# Copyright (c) 2025, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Intel Corporation nor the names of its contributors
+#       may be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+[build-system]
+requires = ["setuptools>=64", "Cython", "numpy"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mkl_fft"
+dynamic = ["version"]
+description = "MKL-based FFT transforms for NumPy arrays"
+readme = { file = "README.md", content-type = "text/markdown" }
+requires-python = ">=3.7"
+license = { text = "BSD" }
+authors = [
+    { name = "Intel Corporation", email = "scripting@intel.com" }
+]
+keywords = ["DFTI", "FFT", "Fourier", "MKL"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved",
+    "Programming Language :: C",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Software Development",
+    "Topic :: Scientific/Engineering",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Operating System :: MacOS"
+]
+dependencies = ["numpy >=1.16", "mkl", "mkl-service"]
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[project.urls]
+Homepage = "http://github.com/IntelPython/mkl_fft"
+Download = "http://github.com/IntelPython/mkl_fft"
+
+[tool.setuptools]
+packages = ["mkl_fft", "mkl_fft.interfaces"]
+include-package-data = true
+
+[tool.setuptools.package-data]
+"mkl_fft" = ["tests/*.py"]
+
+[tool.setuptools.dynamic]
+version = {attr = "mkl_fft._version.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ name = "mkl_fft"
 dynamic = ["version"]
 description = "MKL-based FFT transforms for NumPy arrays"
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.7"
+requires-python = ">=3.9,<3.13"
 license = { text = "BSD" }
 authors = [
     { name = "Intel Corporation", email = "scripting@intel.com" }


### PR DESCRIPTION
Migrating from `setup.py` to `pyproject.toml` to avoid deprecated warning.

>>> DEPRECATION: Legacy editable install of mkl_fft==1.3.11 from file:~/repos/mkl_fft (setup.py develop) is deprecated. pip 25.1 will enforce this behaviour change. A possible replacement is to add a pyproject.toml or enable --use-pep517, and use setuptools >= 64. If the resulting installation is not behaving as expected, try using --config-settings editable_mode=compat. Please consult the setuptools documentation for more information. Discussion can be found at https://github.com/pypa/pip/issues/11457

In addition, `required_python` version is updated to be `3.9>=,<3.13`, numpy version is updated to be `>1.26.4` and also support for macOS is removed since [OneAPI support discontinued](https://www.intel.com/content/www/us/en/docs/oneapi/installation-guide-macos/2024-0/overview.html).