### PR TITLE
 raise warning similar to numpy >= 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,5 +82,5 @@ The package also provides `mkl_fft._numpy_fft` and `mkl_fft._scipy_fft` interfac
 
 To build ``mkl_fft`` from sources on Linux:
   - install a recent version of MKL, if necessary;
-  - execute ``source /path_to_oneapi/mkl/latest/env/vars.sh`` ;
+  - execute ``source /path_to_oneapi/mkl/latest/env/vars.sh``;
   - execute ``python -m pip install .``

--- a/mkl_fft/_float_utils.py
+++ b/mkl_fft/_float_utils.py
@@ -81,7 +81,7 @@ def __downcast_float128_array(x):
 
 def __supported_array_or_not_implemented(x):
     """
-    Used in _scipy_fft_backend to convert array to float32,
+    Used in _scipy_fft to convert array to float32,
     float64, complex64, or complex128 type or return NotImplemented
     """
     __x = np.asarray(x)

--- a/mkl_fft/_numpy_fft.py
+++ b/mkl_fft/_numpy_fft.py
@@ -1249,11 +1249,9 @@ def rfftn(a, s=None, axes=None, norm=None):
         fsc = 1.0
     elif norm == "forward":
         x = asanyarray(x)
-        s, axes = _cook_nd_args(x, s, axes)
         fsc = frwd_sc_nd(s, x.shape)
     else:
         x = asanyarray(x)
-        s, axes = _cook_nd_args(x, s, axes)
         fsc = sqrt(frwd_sc_nd(s, x.shape))
 
     return trycall(

--- a/mkl_fft/_numpy_fft.py
+++ b/mkl_fft/_numpy_fft.py
@@ -73,6 +73,7 @@ __all__ = [
 import re
 import warnings
 
+import numpy as np
 from numpy import array, asanyarray, conjugate, prod, sqrt, take
 
 from . import _float_utils
@@ -701,7 +702,7 @@ def _cook_nd_args(a, s=None, axes=None, invreal=False):
         shapeless = False
     s = list(s)
     if axes is None:
-        if not shapeless:
+        if not shapeless and np.__version__ >= "2.0":
             msg = (
                 "`axes` should not be `None` if `s` is not `None` "
                 "(Deprecated in NumPy 2.0). In a future version of NumPy, "
@@ -716,7 +717,7 @@ def _cook_nd_args(a, s=None, axes=None, invreal=False):
         raise ValueError("Shape and axes have different lengths.")
     if invreal and shapeless:
         s[-1] = (a.shape[axes[-1]] - 1) * 2
-    if None in s:
+    if None in s and np.__version__ >= "2.0":
         msg = (
             "Passing an array containing `None` values to `s` is "
             "deprecated in NumPy 2.0 and will raise an error in "

--- a/mkl_fft/_pydfti.pyx
+++ b/mkl_fft/_pydfti.pyx
@@ -1100,7 +1100,7 @@ def _fftnd_impl(x, s=None, axes=None, overwrite_x=False, direction=+1, double fs
                 _direct_fftnd,
                 {'overwrite_x': overwrite_x, 'direction': direction, 'fsc': fsc},
                 res
-                )
+            )
         else:
             sc = <object> fsc
             return _iter_fftnd(x, s=s, axes=axes,
@@ -1200,7 +1200,7 @@ def rfftn(x, s=None, axes=None, fwd_scale=1.0):
             a = _fix_dimensions(a, tuple(ss), axes)
         if len(set(axes)) == len(axes) and len(axes) == a.ndim and len(axes) > 2:
             ss, aa = _remove_axis(s, axes, -1)
-            ind = [slice(None,None,1),] * len(s)
+            ind = [slice(None, None, 1),] * len(s)
             for ii in range(a.shape[la]):
                 ind[la] = ii
                 tind = tuple(ind)

--- a/mkl_fft/_scipy_fft.py
+++ b/mkl_fft/_scipy_fft.py
@@ -43,7 +43,7 @@ via `scipy.fft` namespace.
 
 :Example:
     import scipy.fft
-    import mkl_fft._scipy_fft_backend as be
+    import mkl_fft._scipy_fft as be
     # Set mkl_fft to be used as backend of SciPy's FFT functions.
     scipy.fft.set_global_backend(be)
 """

--- a/mkl_fft/tests/test_interfaces.py
+++ b/mkl_fft/tests/test_interfaces.py
@@ -121,6 +121,7 @@ def test_scipy_rfftn(norm, dtype):
     assert np.allclose(x, xx, atol=tol, rtol=tol)
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.parametrize("norm", [None, "forward", "backward", "ortho"])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_numpy_rfftn(norm, dtype):

--- a/mkl_fft/tests/test_pocketfft.py
+++ b/mkl_fft/tests/test_pocketfft.py
@@ -19,6 +19,10 @@ from numpy.testing import (
 
 import mkl_fft.interfaces.numpy_fft as mkl_fft
 
+requires_numpy_2 = pytest.mark.skipif(
+    np.__version__ < "2.0", reason="Requires NumPy >= 2.0"
+)
+
 
 def fft1(x):
     L = len(x)
@@ -510,7 +514,7 @@ class TestFFT1D:
         # should use the whole input array along the first axis
         assert op(x, s=(-1, 5), axes=(0, 1)).shape == (10, 5)
 
-    @pytest.mark.skipif(np.__version__ < "2.0", reason="Requires numpy >= 2.0")
+    @requires_numpy_2
     @pytest.mark.parametrize(
         "op", [mkl_fft.fftn, mkl_fft.ifftn, mkl_fft.rfftn, mkl_fft.irfftn]
     )
@@ -519,14 +523,14 @@ class TestFFT1D:
         with pytest.warns(match="`axes` should not be `None` if `s`"):
             op(x, s=(-1, 5))
 
-    @pytest.mark.skipif(np.__version__ < "2.0", reason="Requires numpy >= 2.0")
+    @requires_numpy_2
     @pytest.mark.parametrize("op", [mkl_fft.fft2, mkl_fft.ifft2])
     def test_s_axes_none_2D(self, op):
         x = np.arange(100).reshape(10, 10)
         with pytest.warns(match="`axes` should not be `None` if `s`"):
             op(x, s=(-1, 5), axes=None)
 
-    @pytest.mark.skipif(np.__version__ < "2.0", reason="Requires numpy >= 2.0")
+    @requires_numpy_2
     @pytest.mark.parametrize(
         "op",
         [

--- a/mkl_fft/tests/test_pocketfft.py
+++ b/mkl_fft/tests/test_pocketfft.py
@@ -519,7 +519,6 @@ class TestFFT1D:
         with pytest.warns(match="`axes` should not be `None` if `s`"):
             op(x, s=(-1, 5))
 
-    @pytest.mark.skip("no warning is raised in mkl_ftt")
     @pytest.mark.parametrize("op", [mkl_fft.fft2, mkl_fft.ifft2])
     def test_s_axes_none_2D(self, op):
         x = np.arange(100).reshape(10, 10)

--- a/mkl_fft/tests/test_pocketfft.py
+++ b/mkl_fft/tests/test_pocketfft.py
@@ -510,7 +510,7 @@ class TestFFT1D:
         # should use the whole input array along the first axis
         assert op(x, s=(-1, 5), axes=(0, 1)).shape == (10, 5)
 
-    @pytest.mark.skip("no warning is raised in mkl_ftt")
+    @pytest.mark.skipif(np.__version__ < "2.0", reason="Requires numpy >= 2.0")
     @pytest.mark.parametrize(
         "op", [mkl_fft.fftn, mkl_fft.ifftn, mkl_fft.rfftn, mkl_fft.irfftn]
     )
@@ -519,13 +519,14 @@ class TestFFT1D:
         with pytest.warns(match="`axes` should not be `None` if `s`"):
             op(x, s=(-1, 5))
 
+    @pytest.mark.skipif(np.__version__ < "2.0", reason="Requires numpy >= 2.0")
     @pytest.mark.parametrize("op", [mkl_fft.fft2, mkl_fft.ifft2])
     def test_s_axes_none_2D(self, op):
         x = np.arange(100).reshape(10, 10)
         with pytest.warns(match="`axes` should not be `None` if `s`"):
             op(x, s=(-1, 5), axes=None)
 
-    @pytest.mark.skip("no warning is raised in mkl_ftt")
+    @pytest.mark.skipif(np.__version__ < "2.0", reason="Requires numpy >= 2.0")
     @pytest.mark.parametrize(
         "op",
         [


### PR DESCRIPTION
In this PR, numpy interface is updated to raise similar warning to numpy >= 2.0.