### PR TITLE
Support mkl_fft in virtual environment out of the box

### DIFF
--- a/mkl_fft/__init__.py
+++ b/mkl_fft/__init__.py
@@ -33,3 +33,5 @@ import mkl_fft.interfaces
 
 __all__ = ['fft', 'ifft', 'fft2', 'ifft2', 'fftn', 'ifftn', 'rfftpack', 'irfftpack'
            'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn', 'irfftn','interfaces']
+
+del _init_helper

--- a/mkl_fft/__init__.py
+++ b/mkl_fft/__init__.py
@@ -24,6 +24,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from . import _init_helper
 from ._pydfti import (fft, ifft, fft2, ifft2, fftn, ifftn, rfftpack, irfftpack,
                       rfft, irfft, rfft2, irfft2, rfftn, irfftn)
 

--- a/mkl_fft/_init_helper.py
+++ b/mkl_fft/_init_helper.py
@@ -1,0 +1,30 @@
+# Copyright 2020-2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import os.path
+import sys
+
+is_venv_win32 = (
+    sys.platform == "win32"
+    and sys.base_exec_prefix != sys.exec_prefix
+    and os.path.isfile(os.path.join(sys.exec_prefix, "pyvenv.cfg"))
+)
+
+if is_venv_win32:
+    dll_dir = os.path.join(sys.exec_prefix, "Library", "bin")
+    if os.path.isdir(dll_dir):
+        os.add_dll_directory(dll_dir)
+
+del is_venv_win32

--- a/mkl_fft/_init_helper.py
+++ b/mkl_fft/_init_helper.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Intel Corporation
+# Copyright 2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ is_venv_win32 = (
 )
 
 if is_venv_win32:
+    # In Windows venv: add Library/bin to PATH for proper DLL loading
     dll_dir = os.path.join(sys.exec_prefix, "Library", "bin")
     if os.path.isdir(dll_dir):
         os.add_dll_directory(dll_dir)


### PR DESCRIPTION
Since location of "Library\bin" in the virtual environment is not on the default search path, importing of mkl_fft and numpy fails.

This change introduces "_init_helper.py" file which implements the following logic using built-in os Python module:
1. If os.add_dll_directory attribute exists, and VIRTUAL_ENV environment variable is set, and os.path.join(os.environ["VIRTUAL_ENV"], "Library", "bin") folder exists, call os.add_dll_directory with that directory