### PR TITLE
Remove Mac deployment target from build scripts

### DIFF
--- a/conda-recipe-cf/build.sh
+++ b/conda-recipe-cf/build.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -x
 
-if [ "$(uname)" == Darwin ]; then
-    export MACOSX_DEPLOYMENT_TARGET=10.9
-fi
-
 export MKLROOT=$PREFIX
 export CFLAGS="-I$PREFIX/include $CFLAGS"
 $PYTHON -m pip install --no-build-isolation --no-deps .

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -x
 
-if [ "$(uname)" == Darwin ]; then
-    export MACOSX_DEPLOYMENT_TARGET=10.9
-fi
-
 export MKLROOT=$PREFIX
 export CFLAGS="-I$PREFIX/include $CFLAGS"
 $PYTHON -m pip install --no-build-isolation --no-deps .


### PR DESCRIPTION
Mac is no longer supported