### PR TITLE
update `pyproject.toml`

### DIFF
--- a/conda-recipe-cf/meta.yaml
+++ b/conda-recipe-cf/meta.yaml
@@ -18,13 +18,12 @@ requirements:
       - {{ compiler('c') }}
     host:
       - python
-      - setuptools
+      - setuptools >=77
       - mkl-devel
       - cython
       - numpy
     run:
       - python
-      - mkl
       - mkl-service
       - numpy
 
@@ -41,6 +40,6 @@ test:
 
 about:
     home: http://github.com/IntelPython/mkl_fft
-    license: BSD-3
+    license: BSD-3-Clause
     license_file: LICENSE.txt
     summary: NumPy-based implementation of Fast Fourier Transform using Intel (R) Math Kernel Library

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,13 +18,12 @@ requirements:
       - {{ compiler('c') }}
     host:
       - python
-      - setuptools
+      - setuptools >=77
       - mkl-devel
       - cython
       - numpy-base
     run:
       - python
-      - mkl
       - mkl-service
       - {{ pin_compatible('numpy') }}
 
@@ -41,6 +40,6 @@ test:
 
 about:
     home: http://github.com/IntelPython/mkl_fft
-    license: BSD-3
+    license: BSD-3-Clause
     license_file: LICENSE.txt
     summary: NumPy-based implementation of Fast Fourier Transform using Intel (R) Math Kernel Library

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@
 
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=64", "Cython", "numpy"]
+requires = ["setuptools>=77", "Cython", "numpy", "mkl-devel"]
 
 [project]
 authors = [
@@ -35,7 +35,6 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Science/Research",
   "Intended Audience :: Developers",
-  "License :: OSI Approved",
   "Programming Language :: C",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
@@ -50,11 +49,11 @@ classifiers = [
   "Operating System :: POSIX",
   "Operating System :: Unix"
 ]
-dependencies = ["numpy >=1.26.4", "mkl", "mkl-service"]
+dependencies = ["numpy>=1.26.4", "mkl-service"]
 description = "MKL-based FFT transforms for NumPy arrays"
 dynamic = ["version"]
 keywords = ["DFTI", "FFT", "Fourier", "MKL"]
-license = {text = "BSD"}
+license = "BSD-3-Clause"
 name = "mkl_fft"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.9,<3.13"


### PR DESCRIPTION
In this PR,

1) `mkl-devel` is added to required packages for build.
2) `mkl` is removed from dependency at run time (`mkl-service` is already included which depends on `mkl` and so `mkl-service` automatically installs `mkl`)
3) changes are made to avoid `SetuptoolsDeprecationWarning` visible when `--verbose` is used with `pip install -e .`

<details>
  <summary>Click to see deprecated warning</summary>
/home/runner/miniconda3/envs/test/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
  !!

          ********************************************************************************
          Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

          By 2026-Feb-18, you need to update your project and remove deprecated calls
          or your builds will no longer be supported.

          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************

  !!
    corresp(dist, value, root_dir)
  /home/runner/miniconda3/envs/test/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
  !!

          ********************************************************************************
          Please consider removing the following classifiers in favor of a SPDX license expression:

          License :: OSI Approved

          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************

  !!
    dist._finalize_license_expression()
  /home/runner/miniconda3/envs/test/lib/python3.11/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
  !!

          ********************************************************************************
          Please consider removing the following classifiers in favor of a SPDX license expression:

          License :: OSI Approved

          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************
</details>

4) as part of getting rid of deprecated warning in No. 3, `setuptools` should be `>=77.0.0`.