### PR TITLE
update GitHub workfkows

### DIFF
--- a/.github/workflows/build_pip.yaml
+++ b/.github/workflows/build_pip.yaml
@@ -40,6 +40,7 @@ jobs:
           use-mamba: true
           miniforge-version: latest
           channels: conda-forge
+          conda-remove-defaults: true
           activate-environment: test
           python-version: ${{ matrix.python }}
 
@@ -52,9 +53,9 @@ jobs:
 
       - name: Build conda package
         run: |
-          pip install --no-cache-dir cython pytest hypothesis
+          pip install --no-cache-dir cython
           pip install --no-cache-dir numpy ${{ matrix.use_pre }}
           echo "CONDA_PREFFIX is '${CONDA_PREFIX}'"
           export MKLROOT=${CONDA_PREFIX}
-          pip install -e . --no-build-isolation --verbose --no-deps
+          pip install -e .[test] --no-build-isolation --verbose
           python -m pytest -v mkl_fft/tests

--- a/.github/workflows/build_pip.yaml
+++ b/.github/workflows/build_pip.yaml
@@ -58,4 +58,5 @@ jobs:
           echo "CONDA_PREFFIX is '${CONDA_PREFIX}'"
           export MKLROOT=${CONDA_PREFIX}
           pip install -e .[test] --no-build-isolation --verbose
+          pip list
           python -m pytest -v mkl_fft/tests

--- a/.github/workflows/conda-package-cf.yml
+++ b/.github/workflows/conda-package-cf.yml
@@ -16,7 +16,7 @@ env:
   VER_SCRIPT2: "print('='.join((d[s] for s in ('version', 'build'))))"
 
 jobs:
-  build:
+  build_linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -62,8 +62,8 @@ jobs:
           name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python }}
           path: /usr/share/miniconda/conda-bld/linux-64/${{ env.PACKAGE_NAME }}-*.conda
 
-  test:
-    needs: build
+  test_linux:
+    needs: build_linux
     runs-on:  ${{ matrix.runner }}
 
     strategy:
@@ -142,7 +142,7 @@ jobs:
           auto-activate-base: true
           activate-environment: build
           python-version: ${{ matrix.python }}
-          channels: conda-forge,nodefaults
+          channels: conda-forge
           conda-remove-defaults: 'true'
 
       - name: Install conda-build

--- a/.github/workflows/conda-package-cf.yml
+++ b/.github/workflows/conda-package-cf.yml
@@ -139,7 +139,6 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          auto-activate-base: true
           activate-environment: build
           python-version: ${{ matrix.python }}
           channels: conda-forge

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -16,11 +16,11 @@ env:
   VER_SCRIPT2: "print('='.join((d[s] for s in ('version', 'build'))))"
 
 jobs:
-  build:
+  build_linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.9', '3.10']
+        python: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
         with:
@@ -62,13 +62,13 @@ jobs:
           name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python }}
           path: /usr/share/miniconda/conda-bld/linux-64/${{ env.PACKAGE_NAME }}-*.conda
 
-  test:
-    needs: build
+  test_linux:
+    needs: build_linux
     runs-on:  ${{ matrix.runner }}
 
     strategy:
       matrix:
-        python: ['3.9', '3.10']
+        python: ['3.9', '3.10', '3.11', '3.12']
         experimental: [false]
         runner: [ubuntu-latest]
     continue-on-error: ${{ matrix.experimental }}
@@ -130,7 +130,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.9', '3.10']
+        python: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4.2.0
         with:
@@ -184,7 +184,7 @@ jobs:
         shell: cmd /C CALL {0}
     strategy:
       matrix:
-        python: ['3.9', '3.10']
+        python: ['3.9', '3.10', '3.11', '3.12']
         experimental: [false]
         runner: [windows-2019]
     continue-on-error: ${{ matrix.experimental }}


### PR DESCRIPTION
In this PR, 
1) GitHub work flow for build pip is update to avoid a warning.
<details>
  <summary>Click to see the warning</summary>
  Warning: The 'defaults' channel might have been added implicitly. If this is intentional, add 'defaults' to the 'channels' list. Otherwise, consider setting 'conda-remove-defaults' to 'true'.
</details>

2) Build step in GitHub work flow for build pip is updated to use `optional-dependencies` to install packages needed for test.

3) Python 3.11 and 3.12 are added to matrix test of conda package.