### PR TITLE
update workflows to pin python-3.12 when installing conda-build

### DIFF
--- a/.github/workflows/conda-package-cf.yml
+++ b/.github/workflows/conda-package-cf.yml
@@ -51,7 +51,7 @@ jobs:
         run: echo $CONDA/bin >> $GITHUB_PATH
 
       - name: Install conda-build
-        run: conda install conda-build
+        run: conda install conda-build python=3.12
 
       - name: Build conda package with NumPy 2.0
         run: |
@@ -95,7 +95,7 @@ jobs:
         run: echo $CONDA/bin >> $GITHUB_PATH
 
       - name: Install conda-build
-        run: conda install conda-build
+        run: conda install conda-build python=3.12
 
       - name: Create conda channel
         run: |
@@ -167,7 +167,7 @@ jobs:
           conda-remove-defaults: 'true'
 
       - name: Install conda-build
-        run: conda install -n base conda-build
+        run: conda install -n base conda-build python=3.12
 
       - name: Cache conda packages
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -51,7 +51,7 @@ jobs:
         run: echo $CONDA/bin >> $GITHUB_PATH
 
       - name: Install conda-build
-        run: conda install conda-build
+        run: conda install conda-build python=3.12
 
       - name: Build conda package
         run: |
@@ -94,7 +94,7 @@ jobs:
         run: echo $CONDA/bin >> $GITHUB_PATH
 
       - name: Install conda-build
-        run: conda install conda-build
+        run: conda install conda-build python=3.12
 
       - name: Create conda channel
         run: |
@@ -168,7 +168,7 @@ jobs:
       - name: Install conda-build
         run: |
            conda activate
-           conda install -n base conda-build
+           conda install -n base conda-build python=3.12
 
       - name: Cache conda packages
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3


### PR DESCRIPTION
`conda-build` is not available for python-3.13. In this PR, python-3.12 is pinned to be used when installing `conda-build`.

```
LibMambaUnsatisfiableError: Encountered problems while solving:
  - package conda-build-3.0.22-py27h62b9468_0 requires python >=2.7,<2.8.0a0, but none of the providers can be installed

Could not solve for environment specs
The following packages are incompatible
├─ conda-build =* * is installable with the potential options
│  ├─ conda-build [24.1.0|24.1.1|...|3.28.4] would require
│  │  └─ python >=3.10,<3.11.0a0 *, which can be installed;
│  ├─ conda-build [24.1.0|24.1.1|...|3.28.4] would require
│  │  └─ python >=3.11,<3.12.0a0 *, which can be installed;
│  ├─ conda-build [24.1.0|24.1.1|...|25.4.2] would require
│  │  └─ python >=3.12,<3.13.0a0 *, which can be installed;
│  ├─ conda-build [24.1.0|24.1.1|...|3.28.4] would require
│  │  └─ python >=3.8,<3.9.0a0 *, which can be installed;
│  ├─ conda-build [24.1.0|24.1.1|...|3.28.4] would require
│  │  └─ python >=3.9,<3.10.0a0 *, which can be installed;
│  ├─ conda-build [3.0.[22](https://github.com/IntelPython/mkl_fft/actions/runs/14841581791/job/41667416133?pr=168#step:7:23)|3.0.23|...|3.9.2] would require
│  │  └─ python >=2.7,<2.8.0a0 *, which can be installed;
│  ├─ conda-build [3.0.22|3.0.[23](https://github.com/IntelPython/mkl_fft/actions/runs/14841581791/job/41667416133?pr=168#step:7:24)|...|3.9.2] would require
│  │  └─ python >=3.5,<3.6.0a0 *, which can be installed;
│  ├─ conda-build [3.0.22|3.0.23|...|3.9.2] would require
│  │  └─ python >=3.6,<3.7.0a0 *, which can be installed;
│  └─ conda-build [3.10.9|3.11.0|...|3.23.3] would require
│     └─ python >=3.7,<3.8.0a0 *, which can be installed;
└─ pin on python 3.13.* =* * is not installable because it requires
   └─ python =3.13 *, which conflicts with any installable versions previously reported.

Pins seem to be involved in the conflict. Currently pinned specs:
 - python=3.13
 ```