### PR TITLE
use `PyLong_AsLong` instead of `PyInt_AsLong`

### DIFF
--- a/.github/workflows/conda-package-cf.yml
+++ b/.github/workflows/conda-package-cf.yml
@@ -295,8 +295,8 @@ jobs:
           FOR /F "tokens=* USEBACKQ" %%F IN (`python -c "%SCRIPT%"`) DO (
              SET PACKAGE_VERSION=%%F
           )
-          SET "TEST_DEPENDENCIES=pytest pytest-cov"
-          conda install -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %TEST_DEPENDENCIES% python=${{ matrix.python }} ${{ matrix.numpy }} scipy -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
+          SET "TEST_DEPENDENCIES=pytest scipy"
+          conda install -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %TEST_DEPENDENCIES% python=${{ matrix.python }} ${{ matrix.numpy }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
 
       - name: Report content of test environment
         shell: cmd /C CALL {0}

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -131,7 +131,8 @@ jobs:
       - name: Install mkl_fft
         run: |
           CHANNELS="-c $GITHUB_WORKSPACE/channel ${{ env.CHANNELS }}"
-          conda create -n ${{ env.TEST_ENV_NAME }} python=${{ matrix.python }} $PACKAGE_NAME pytest scipy $CHANNELS
+          conda create -n ${{ env.TEST_ENV_NAME }} python=${{ matrix.python }} "scipy>=1.10" $CHANNELS
+          conda install -n ${{ env.TEST_ENV_NAME }} $PACKAGE_NAME pytest $CHANNELS
           # Test installed packages
           conda list -n ${{ env.TEST_ENV_NAME }}
 
@@ -295,8 +296,8 @@ jobs:
           FOR /F "tokens=* USEBACKQ" %%F IN (`python -c "%SCRIPT%"`) DO (
              SET PACKAGE_VERSION=%%F
           )
-          SET "TEST_DEPENDENCIES=pytest pytest-cov"
-          conda install -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %TEST_DEPENDENCIES% python=${{ matrix.python }} scipy -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
+          SET "TEST_DEPENDENCIES=pytest scipy"
+          conda install -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %TEST_DEPENDENCIES% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
 
       - name: Report content of test environment
         shell: cmd /C CALL {0}
@@ -304,6 +305,7 @@ jobs:
           echo "Value of CONDA environment variable was: " %CONDA%
           echo "Value of CONDA_PREFIX environment variable was: " %CONDA_PREFIX%
           conda info && conda list -n ${{ env.TEST_ENV_NAME }}
+
       - name: Run tests
         shell: cmd /C CALL {0}
         run: >-

--- a/mkl_fft/_pydfti.pyx
+++ b/mkl_fft/_pydfti.pyx
@@ -89,7 +89,7 @@ def _tls_dfti_cache_capsule():
 cdef extern from "Python.h":
     ctypedef int size_t
 
-    long PyInt_AsLong(object ob)
+    long PyLong_AsLong(object ob)
     int PyObject_HasAttrString(object, char*)
 
 
@@ -262,7 +262,7 @@ cdef cnp.ndarray _process_arguments(
     xnd[0] = cnp.PyArray_NDIM(x_arr)  # tensor-rank of the array
 
     err = 0
-    axis_[0] = PyInt_AsLong(axis)
+    axis_[0] = PyLong_AsLong(axis)
     if (axis_[0] == -1 and PyErr_Occurred()):
         PyErr_Clear()
         err = 1
@@ -278,7 +278,7 @@ cdef cnp.ndarray _process_arguments(
         n_[0] = x_arr.shape[axis_[0]]
     else:
         try:
-            n_[0] = PyInt_AsLong(n)
+            n_[0] = PyLong_AsLong(n)
         except:
             err = 1
 
@@ -334,7 +334,7 @@ cdef int _is_integral(object num):
     if num is None:
         return 0
     try:
-        n = PyInt_AsLong(num)
+        n = PyLong_AsLong(num)
         _integral = 1 if n > 0 else 0
     except:
         _integral = 0


### PR DESCRIPTION
[`PyInt_AsLong`](https://docs.python.org/2/c-api/int.html#:~:text=long%20PyInt_AsLong(PyObject%C2%A0*io)) is deprecated and [`PyLong_AsLong`](https://docs.python.org/3/c-api/long.html#:~:text=long%20PyLong_AsLong(PyObject%20*obj)%C2%B6) should be used with python3.