### PR TITLE
add scipy to runtime dependency

### DIFF
--- a/.github/workflows/conda-package-cf.yml
+++ b/.github/workflows/conda-package-cf.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Install mkl_fft
         run: |
           CHANNELS="-c $GITHUB_WORKSPACE/channel ${{ env.CHANNELS }}"
-          conda create -n ${{ env.TEST_ENV_NAME }} python=${{ matrix.python_ver }} ${{ matrix.numpy }} $PACKAGE_NAME pytest scipy $CHANNELS
+          conda create -n ${{ env.TEST_ENV_NAME }} python=${{ matrix.python_ver }} ${{ matrix.numpy }} $PACKAGE_NAME pytest $CHANNELS
           # Test installed packages
           conda list -n ${{ env.TEST_ENV_NAME }}
 
@@ -295,7 +295,7 @@ jobs:
           FOR /F "tokens=* USEBACKQ" %%F IN (`python -c "%SCRIPT%"`) DO (
              SET PACKAGE_VERSION=%%F
           )
-          SET "TEST_DEPENDENCIES=pytest scipy"
+          SET "TEST_DEPENDENCIES=pytest"
           conda install -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %TEST_DEPENDENCIES% python=${{ matrix.python }} ${{ matrix.numpy }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
 
       - name: Report content of test environment

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -131,8 +131,7 @@ jobs:
       - name: Install mkl_fft
         run: |
           CHANNELS="-c $GITHUB_WORKSPACE/channel ${{ env.CHANNELS }}"
-          conda create -n ${{ env.TEST_ENV_NAME }} python=${{ matrix.python }} "scipy>=1.10" $CHANNELS
-          conda install -n ${{ env.TEST_ENV_NAME }} $PACKAGE_NAME pytest $CHANNELS
+          conda create -n ${{ env.TEST_ENV_NAME }} $PACKAGE_NAME python=${{ matrix.python }} pytest $CHANNELS
           # Test installed packages
           conda list -n ${{ env.TEST_ENV_NAME }}
 
@@ -296,7 +295,7 @@ jobs:
           FOR /F "tokens=* USEBACKQ" %%F IN (`python -c "%SCRIPT%"`) DO (
              SET PACKAGE_VERSION=%%F
           )
-          SET "TEST_DEPENDENCIES=pytest scipy"
+          SET "TEST_DEPENDENCIES=pytest"
           conda install -n ${{ env.TEST_ENV_NAME }} ${{ env.PACKAGE_NAME }}=%PACKAGE_VERSION% %TEST_DEPENDENCIES% python=${{ matrix.python }} -c ${{ env.workdir }}/channel ${{ env.CHANNELS }}
 
       - name: Report content of test environment

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ __pycache__/
 
 mkl_fft/_pydfti.c
 mkl_fft/_pydfti.cpython*.so
+mkl_fft/_pydfti.*-win_amd64.pyd
 mkl_fft/src/mklfft.c

--- a/conda-recipe-cf/meta.yaml
+++ b/conda-recipe-cf/meta.yaml
@@ -26,13 +26,13 @@ requirements:
       - python
       - mkl-service
       - numpy
+      - scipy >=1.10.1
 
 test:
     commands:
       - pytest -v --pyargs mkl_fft
     requires:
       - pytest
-      - scipy
     imports:
       - mkl_fft
       - mkl_fft.interfaces

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,13 +26,13 @@ requirements:
       - python
       - mkl-service
       - {{ pin_compatible('numpy') }}
+      - scipy >=1.10.1
 
 test:
     commands:
       - pytest -v --pyargs mkl_fft
     requires:
       - pytest
-      - scipy
     imports:
       - mkl_fft
       - mkl_fft.interfaces

--- a/mkl_fft/tests/third_party/scipy/test_basic.py
+++ b/mkl_fft/tests/third_party/scipy/test_basic.py
@@ -13,10 +13,10 @@ from numpy.testing import assert_allclose, assert_array_almost_equal
 from pytest import raises as assert_raises
 
 # pylint: disable=possibly-used-before-assignment
-if scipy.__version__ < "1.12":
+if np.lib.NumpyVersion(scipy.__version__) < "1.12.0":
     # scipy from Intel channel is 1.10 with python 3.9 and 3.10
     pytest.skip("This test file needs scipy>=1.12", allow_module_level=True)
-elif scipy.__version__ < "1.14":
+elif np.lib.NumpyVersion(scipy.__version__) < "1.14.0":
     # For python-3.11 and 3.12, scipy<1.14 is installed from Intel channel
     # For python<=3.9, scipy<1.14 is installed from conda channel
     # pylint: disable=no-name-in-module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ classifiers = [
   "Operating System :: POSIX",
   "Operating System :: Unix"
 ]
-dependencies = ["numpy>=1.26.4", "mkl-service"]
+dependencies = ["numpy>=1.26.4", "mkl-service", "scipy>=1.10.1"]
 description = "MKL-based FFT transforms for NumPy arrays"
 dynamic = ["version"]
 keywords = ["DFTI", "FFT", "Fourier", "MKL"]
@@ -59,7 +59,7 @@ readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.9,<3.13"
 
 [project.optional-dependencies]
-test = ["pytest", "scipy"]
+test = ["pytest"]
 
 [project.urls]
 Download = "http://github.com/IntelPython/mkl_fft"


### PR DESCRIPTION
In https://github.com/IntelPython/mkl_fft/pull/179, we added helper functions [directly from SciPy](https://github.com/IntelPython/mkl_fft/blob/master/mkl_fft/interfaces/scipy_fft.py#L29) for expanding the functionality of `mkl_fft.interfaces.scipy_fft` module. This addition means that `scipy` is now a runtime dependency. In this PR it is added to the project as a runtime dependency.