### PR TITLE
replace `fwd_scale` with `norm` kwarg in `mkl_fft`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Enabled support of Python 3.13 [gh-164](https://github.com/IntelPython/mkl_fft/pull/164)
 
 ### Changed
+* Replaced `fwd_scale` parameter with `norm` in `mkl_fft` [gh-189](https://github.com/IntelPython/mkl_fft/pull/189)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -51,21 +51,21 @@ While using the interfaces module is the recommended way to leverage `mk_fft`, o
 
 ### complex-to-complex (c2c) transforms:
 
-`fft(x, n=None, axis=-1, overwrite_x=False, fwd_scale=1.0, out=None)` - 1D FFT, similar to `scipy.fft.fft`
+`fft(x, n=None, axis=-1, overwrite_x=False, norm=None, out=None)` - 1D FFT, similar to `scipy.fft.fft`
 
-`fft2(x, s=None, axes=(-2, -1), overwrite_x=False, fwd_scale=1.0, out=None)` - 2D FFT, similar to `scipy.fft.fft2`
+`fft2(x, s=None, axes=(-2, -1), overwrite_x=False, norm=None, out=None)` - 2D FFT, similar to `scipy.fft.fft2`
 
-`fftn(x, s=None, axes=None, overwrite_x=False, fwd_scale=1.0, out=None)` - ND FFT, similar to `scipy.fft.fftn`
+`fftn(x, s=None, axes=None, overwrite_x=False, norm=None, out=None)` - ND FFT, similar to `scipy.fft.fftn`
 
 and similar inverse FFT (`ifft*`) functions.
 
 ### real-to-complex (r2c) and complex-to-real (c2r) transforms:
 
-`rfft(x, n=None, axis=-1, fwd_scale=1.0, out=None)` - r2c 1D FFT, similar to `numpy.fft.rfft`
+`rfft(x, n=None, axis=-1, norm=None, out=None)` - r2c 1D FFT, similar to `numpy.fft.rfft`
 
-`rfft2(x, s=None, axes=(-2, -1), fwd_scale=1.0, out=None)` - r2c 2D FFT, similar to `numpy.fft.rfft2`
+`rfft2(x, s=None, axes=(-2, -1), norm=None, out=None)` - r2c 2D FFT, similar to `numpy.fft.rfft2`
 
-`rfftn(x, s=None, axes=None, fwd_scale=1.0, out=None)` - r2c ND FFT, similar to `numpy.fft.rfftn`
+`rfftn(x, s=None, axes=None, norm=None, out=None)` - r2c ND FFT, similar to `numpy.fft.rfftn`
 
 and similar inverse c2r FFT (`irfft*`) functions.
 

--- a/mkl_fft/_fft_utils.py
+++ b/mkl_fft/_fft_utils.py
@@ -198,16 +198,12 @@ def _init_nd_shape_and_axes(x, shape, axes):
         raise ValueError("when given, shape values must be integers")
     if axes.shape != shape.shape:
         raise ValueError(
-            "when given, axes and shape arguments"
-            " have to be of the same length"
+            "when given, axes and shape arguments have to be of the same length"
         )
 
     shape = np.where(shape == -1, np.array(x.shape)[axes], shape)
-
     if shape.size != 0 and (shape < 1).any():
-        raise ValueError(
-            "invalid number of data points ({0}) specified".format(shape)
-        )
+        raise ValueError(f"invalid number of data points ({shape}) specified")
 
     return shape, axes
 
@@ -299,7 +295,7 @@ def _pad_array(arr, s, axes):
         try:
             shp_i = arr_shape[ai]
         except IndexError:
-            raise ValueError("Invalid axis (%d) specified" % ai)
+            raise ValueError(f"Invalid axis {ai} specified")
         if si > shp_i:
             no_padding = False
             pad_widths[ai] = (0, si - shp_i)
@@ -335,7 +331,7 @@ def _trim_array(arr, s, axes):
         try:
             shp_i = arr_shape[ai]
         except IndexError:
-            raise ValueError("Invalid axis (%d) specified" % ai)
+            raise ValueError(f"Invalid axis {ai} specified")
         if si < shp_i:
             no_trim = False
             ind[ai] = slice(None, si, None)

--- a/mkl_fft/interfaces/_numpy_fft.py
+++ b/mkl_fft/interfaces/_numpy_fft.py
@@ -36,7 +36,7 @@ import numpy as np
 
 import mkl_fft
 
-from .._fft_utils import _compute_fwd_scale, _swap_direction
+from .._fft_utils import _swap_direction
 from ._float_utils import _downcast_float128_array
 
 __all__ = [
@@ -120,10 +120,8 @@ def fft(a, n=None, axis=-1, norm=None, out=None):
 
     """
     x = _downcast_float128_array(a)
-    fsc = _compute_fwd_scale(norm, n, x.shape[axis])
-
     return _trycall(
-        mkl_fft.fft, (x,), {"n": n, "axis": axis, "fwd_scale": fsc, "out": out}
+        mkl_fft.fft, (x,), {"n": n, "axis": axis, "norm": norm, "out": out}
     )
 
 
@@ -135,10 +133,8 @@ def ifft(a, n=None, axis=-1, norm=None, out=None):
 
     """
     x = _downcast_float128_array(a)
-    fsc = _compute_fwd_scale(norm, n, x.shape[axis])
-
     return _trycall(
-        mkl_fft.ifft, (x,), {"n": n, "axis": axis, "fwd_scale": fsc, "out": out}
+        mkl_fft.ifft, (x,), {"n": n, "axis": axis, "norm": norm, "out": out}
     )
 
 
@@ -171,10 +167,9 @@ def fftn(a, s=None, axes=None, norm=None, out=None):
     """
     x = _downcast_float128_array(a)
     s, axes = _cook_nd_args(x, s, axes)
-    fsc = _compute_fwd_scale(norm, s, x.shape)
 
     return _trycall(
-        mkl_fft.fftn, (x,), {"s": s, "axes": axes, "fwd_scale": fsc, "out": out}
+        mkl_fft.fftn, (x,), {"s": s, "axes": axes, "norm": norm, "out": out}
     )
 
 
@@ -187,12 +182,11 @@ def ifftn(a, s=None, axes=None, norm=None, out=None):
     """
     x = _downcast_float128_array(a)
     s, axes = _cook_nd_args(x, s, axes)
-    fsc = _compute_fwd_scale(norm, s, x.shape)
 
     return _trycall(
         mkl_fft.ifftn,
         (x,),
-        {"s": s, "axes": axes, "fwd_scale": fsc, "out": out},
+        {"s": s, "axes": axes, "norm": norm, "out": out},
     )
 
 
@@ -204,10 +198,9 @@ def rfft(a, n=None, axis=-1, norm=None, out=None):
 
     """
     x = _downcast_float128_array(a)
-    fsc = _compute_fwd_scale(norm, n, x.shape[axis])
 
     return _trycall(
-        mkl_fft.rfft, (x,), {"n": n, "axis": axis, "fwd_scale": fsc, "out": out}
+        mkl_fft.rfft, (x,), {"n": n, "axis": axis, "norm": norm, "out": out}
     )
 
 
@@ -219,12 +212,11 @@ def irfft(a, n=None, axis=-1, norm=None, out=None):
 
     """
     x = _downcast_float128_array(a)
-    fsc = _compute_fwd_scale(norm, n, 2 * (x.shape[axis] - 1))
 
     return _trycall(
         mkl_fft.irfft,
         (x,),
-        {"n": n, "axis": axis, "fwd_scale": fsc, "out": out},
+        {"n": n, "axis": axis, "norm": norm, "out": out},
     )
 
 
@@ -257,12 +249,11 @@ def rfftn(a, s=None, axes=None, norm=None, out=None):
     """
     x = _downcast_float128_array(a)
     s, axes = _cook_nd_args(x, s, axes)
-    fsc = _compute_fwd_scale(norm, s, x.shape)
 
     return _trycall(
         mkl_fft.rfftn,
         (x,),
-        {"s": s, "axes": axes, "fwd_scale": fsc, "out": out},
+        {"s": s, "axes": axes, "norm": norm, "out": out},
     )
 
 
@@ -276,12 +267,11 @@ def irfftn(a, s=None, axes=None, norm=None, out=None):
 
     x = _downcast_float128_array(a)
     s, axes = _cook_nd_args(x, s, axes, invreal=True)
-    fsc = _compute_fwd_scale(norm, s, x.shape)
 
     return _trycall(
         mkl_fft.irfftn,
         (x,),
-        {"s": s, "axes": axes, "fwd_scale": fsc, "out": out},
+        {"s": s, "axes": axes, "norm": norm, "out": out},
     )
 
 
@@ -295,12 +285,10 @@ def hfft(a, n=None, axis=-1, norm=None, out=None):
     """
     norm = _swap_direction(norm)
     x = _downcast_float128_array(a)
-    fsc = _compute_fwd_scale(norm, n, 2 * (x.shape[axis] - 1))
-
     return _trycall(
         mkl_fft.irfft,
         (np.conjugate(x),),
-        {"n": n, "axis": axis, "fwd_scale": fsc, "out": out},
+        {"n": n, "axis": axis, "norm": norm, "out": out},
     )
 
 
@@ -313,10 +301,9 @@ def ihfft(a, n=None, axis=-1, norm=None, out=None):
     """
     norm = _swap_direction(norm)
     x = _downcast_float128_array(a)
-    fsc = _compute_fwd_scale(norm, n, x.shape[axis])
 
     result = _trycall(
-        mkl_fft.rfft, (x,), {"n": n, "axis": axis, "fwd_scale": fsc, "out": out}
+        mkl_fft.rfft, (x,), {"n": n, "axis": axis, "norm": norm, "out": out}
     )
 
     np.conjugate(result, out=result)

--- a/mkl_fft/interfaces/_scipy_fft.py
+++ b/mkl_fft/interfaces/_scipy_fft.py
@@ -39,7 +39,7 @@ import numpy as np
 
 import mkl_fft
 
-from .._fft_utils import _compute_fwd_scale, _swap_direction
+from .._fft_utils import _swap_direction
 from ._float_utils import _supported_array_or_not_implemented
 
 __all__ = [
@@ -223,11 +223,10 @@ def fft(
     """
     _check_plan(plan)
     x = _validate_input(x)
-    fsc = _compute_fwd_scale(norm, n, x.shape[axis])
 
     with _Workers(workers):
         return mkl_fft.fft(
-            x, n=n, axis=axis, overwrite_x=overwrite_x, fwd_scale=fsc
+            x, n=n, axis=axis, overwrite_x=overwrite_x, norm=norm
         )
 
 
@@ -242,11 +241,10 @@ def ifft(
     """
     _check_plan(plan)
     x = _validate_input(x)
-    fsc = _compute_fwd_scale(norm, n, x.shape[axis])
 
     with _Workers(workers):
         return mkl_fft.ifft(
-            x, n=n, axis=axis, overwrite_x=overwrite_x, fwd_scale=fsc
+            x, n=n, axis=axis, overwrite_x=overwrite_x, norm=norm
         )
 
 
@@ -323,11 +321,10 @@ def fftn(
     _check_plan(plan)
     x = _validate_input(x)
     s, axes = _init_nd_shape_and_axes(x, s, axes)
-    fsc = _compute_fwd_scale(norm, s, x.shape)
 
     with _Workers(workers):
         return mkl_fft.fftn(
-            x, s=s, axes=axes, overwrite_x=overwrite_x, fwd_scale=fsc
+            x, s=s, axes=axes, overwrite_x=overwrite_x, norm=norm
         )
 
 
@@ -350,11 +347,10 @@ def ifftn(
     _check_plan(plan)
     x = _validate_input(x)
     s, axes = _init_nd_shape_and_axes(x, s, axes)
-    fsc = _compute_fwd_scale(norm, s, x.shape)
 
     with _Workers(workers):
         return mkl_fft.ifftn(
-            x, s=s, axes=axes, overwrite_x=overwrite_x, fwd_scale=fsc
+            x, s=s, axes=axes, overwrite_x=overwrite_x, norm=norm
         )
 
 
@@ -369,11 +365,10 @@ def rfft(
     """
     _check_plan(plan)
     x = _validate_input(x)
-    fsc = _compute_fwd_scale(norm, n, x.shape[axis])
 
     with _Workers(workers):
         # Note: overwrite_x is not utilized
-        return mkl_fft.rfft(x, n=n, axis=axis, fwd_scale=fsc)
+        return mkl_fft.rfft(x, n=n, axis=axis, norm=norm)
 
 
 def irfft(
@@ -387,11 +382,10 @@ def irfft(
     """
     _check_plan(plan)
     x = _validate_input(x)
-    fsc = _compute_fwd_scale(norm, n, 2 * (x.shape[axis] - 1))
 
     with _Workers(workers):
         # Note: overwrite_x is not utilized
-        return mkl_fft.irfft(x, n=n, axis=axis, fwd_scale=fsc)
+        return mkl_fft.irfft(x, n=n, axis=axis, norm=norm)
 
 
 def rfft2(
@@ -467,11 +461,10 @@ def rfftn(
     _check_plan(plan)
     x = _validate_input(x)
     s, axes = _init_nd_shape_and_axes(x, s, axes)
-    fsc = _compute_fwd_scale(norm, s, x.shape)
 
     with _Workers(workers):
         # Note: overwrite_x is not utilized
-        return mkl_fft.rfftn(x, s, axes, fwd_scale=fsc)
+        return mkl_fft.rfftn(x, s, axes, norm=norm)
 
 
 def irfftn(
@@ -493,11 +486,10 @@ def irfftn(
     _check_plan(plan)
     x = _validate_input(x)
     s, axes = _init_nd_shape_and_axes(x, s, axes, invreal=True)
-    fsc = _compute_fwd_scale(norm, s, x.shape)
 
     with _Workers(workers):
         # Note: overwrite_x is not utilized
-        return mkl_fft.irfftn(x, s, axes, fwd_scale=fsc)
+        return mkl_fft.irfftn(x, s, axes, norm=norm)
 
 
 def hfft(
@@ -515,11 +507,10 @@ def hfft(
     norm = _swap_direction(norm)
     x = np.array(x, copy=True)
     np.conjugate(x, out=x)
-    fsc = _compute_fwd_scale(norm, n, 2 * (x.shape[axis] - 1))
 
     with _Workers(workers):
         # Note: overwrite_x is not utilized
-        return mkl_fft.irfft(x, n=n, axis=axis, fwd_scale=fsc)
+        return mkl_fft.irfft(x, n=n, axis=axis, norm=norm)
 
 
 def ihfft(
@@ -534,11 +525,10 @@ def ihfft(
     _check_plan(plan)
     x = _validate_input(x)
     norm = _swap_direction(norm)
-    fsc = _compute_fwd_scale(norm, n, x.shape[axis])
 
     with _Workers(workers):
         # Note: overwrite_x is not utilized
-        result = mkl_fft.rfft(x, n=n, axis=axis, fwd_scale=fsc)
+        result = mkl_fft.rfft(x, n=n, axis=axis, norm=norm)
 
     np.conjugate(result, out=result)
     return result
@@ -621,11 +611,10 @@ def hfftn(
     x = np.array(x, copy=True)
     np.conjugate(x, out=x)
     s, axes = _init_nd_shape_and_axes(x, s, axes, invreal=True)
-    fsc = _compute_fwd_scale(norm, s, x.shape)
 
     with _Workers(workers):
         # Note: overwrite_x is not utilized
-        return mkl_fft.irfftn(x, s, axes, fwd_scale=fsc)
+        return mkl_fft.irfftn(x, s, axes, norm=norm)
 
 
 def ihfftn(
@@ -648,11 +637,10 @@ def ihfftn(
     x = _validate_input(x)
     norm = _swap_direction(norm)
     s, axes = _init_nd_shape_and_axes(x, s, axes)
-    fsc = _compute_fwd_scale(norm, s, x.shape)
 
     with _Workers(workers):
         # Note: overwrite_x is not utilized
-        result = mkl_fft.rfftn(x, s, axes, fwd_scale=fsc)
+        result = mkl_fft.rfftn(x, s, axes, norm=norm)
 
     np.conjugate(result, out=result)
     return result


### PR DESCRIPTION
Both NumPy and SciPy use `norm` parameter which is the normalization mode that is used scaling the FFT results. `mkl_fft` has the scaling parameter `fwd_scale` directly. In this PR, `fwd_scale` is replaced with `norm` to be aligned with NumPy and SciPy.