### PR TITLE
conditional import `scipy_fft`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ __pycache__/
 
 mkl_fft/_pydfti.c
 mkl_fft/_pydfti.cpython*.so
+mkl_fft/_pydfti.*-win_amd64.pyd
 mkl_fft/src/mklfft.c

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ To build `mkl_fft` from sources on Linux with Intel® OneMKL:
   - `git clone https://github.com/IntelPython/mkl_fft.git mkl_fft`
   - `cd mkl_fft`
   - `python -m pip install .`
+  - `pip install scipy` (optional: for using `mkl_fft.interface.scipy_fft` module)
   - `cd ..`
   - `python -c "import mkl_fft"`
 
@@ -103,5 +104,6 @@ To build `mkl_fft` from sources on Linux with conda follow these steps:
   - `git clone https://github.com/IntelPython/mkl_fft.git mkl_fft`
   - `cd mkl_fft`
   - `python -m pip install .`
+  - `conda install scipy` (optional: for using `mkl_fft.interface.scipy_fft` module)
   - `cd ..`
   - `python -c "import mkl_fft"`

--- a/conda-recipe-cf/meta.yaml
+++ b/conda-recipe-cf/meta.yaml
@@ -32,7 +32,7 @@ test:
       - pytest -v --pyargs mkl_fft
     requires:
       - pytest
-      - scipy
+      - scipy >=1.10
     imports:
       - mkl_fft
       - mkl_fft.interfaces

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -33,7 +33,7 @@ test:
       - pytest -v --pyargs mkl_fft
     requires:
       - pytest
-      - scipy
+      - scipy >=1.10
     imports:
       - mkl_fft
       - mkl_fft.interfaces

--- a/mkl_fft/interfaces/__init__.py
+++ b/mkl_fft/interfaces/__init__.py
@@ -23,4 +23,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from . import numpy_fft, scipy_fft
+from . import numpy_fft
+
+try:
+    import scipy.fft
+except ImportError:
+    pass
+else:
+    from . import scipy_fft

--- a/mkl_fft/tests/third_party/scipy/test_basic.py
+++ b/mkl_fft/tests/third_party/scipy/test_basic.py
@@ -7,22 +7,26 @@ import threading
 
 import numpy as np
 import pytest
-import scipy
 from numpy.random import random
 from numpy.testing import assert_allclose, assert_array_almost_equal
 from pytest import raises as assert_raises
 
 # pylint: disable=possibly-used-before-assignment
-if scipy.__version__ < "1.12":
-    # scipy from Intel channel is 1.10 with python 3.9 and 3.10
-    pytest.skip("This test file needs scipy>=1.12", allow_module_level=True)
-elif scipy.__version__ < "1.14":
-    # For python-3.11 and 3.12, scipy<1.14 is installed from Intel channel
-    # For python<=3.9, scipy<1.14 is installed from conda channel
-    # pylint: disable=no-name-in-module
-    from scipy._lib._array_api import size as xp_size
+try:
+    import scipy
+except ImportError:
+    pytest.skip("This test file needs scipy", allow_module_level=True)
 else:
-    from scipy._lib._array_api import xp_size
+    if np.lib.NumpyVersion(scipy.__version__) < "1.12.0":
+        # scipy from Intel channel is 1.10 with python 3.9 and 3.10
+        pytest.skip("This test file needs scipy>=1.12", allow_module_level=True)
+    elif np.lib.NumpyVersion(scipy.__version__) < "1.14.0":
+        # For python-3.11 and 3.12, scipy<1.14 is installed from Intel channel
+        # For python<=3.9, scipy<1.14 is installed from conda channel
+        # pylint: disable=no-name-in-module
+        from scipy._lib._array_api import size as xp_size
+    else:
+        from scipy._lib._array_api import xp_size
 
 from scipy._lib._array_api import is_numpy, xp_assert_close, xp_assert_equal
 

--- a/mkl_fft/tests/third_party/scipy/test_multithreading.py
+++ b/mkl_fft/tests/third_party/scipy/test_multithreading.py
@@ -8,7 +8,10 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-import mkl_fft.interfaces.scipy_fft as fft
+try:
+    import mkl_fft.interfaces.scipy_fft as fft
+except ImportError:
+    pytest.skip("This test file needs scipy", allow_module_level=True)
 
 
 @pytest.fixture(scope="module")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,8 @@ readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.9,<3.13"
 
 [project.optional-dependencies]
-test = ["pytest", "scipy"]
+scipy_interface = ["scipy>=1.10"]
+test = ["pytest", "scipy>=1.10"]
 
 [project.urls]
 Download = "http://github.com/IntelPython/mkl_fft"


### PR DESCRIPTION
In this PR, `mkl_fft.interface` is modified to only import `scipy_fft` if `scipy` is installed.