### PR TITLE
Update Windows version used by GitHub CI

### DIFF
--- a/.github/workflows/conda-package-cf.yml
+++ b/.github/workflows/conda-package-cf.yml
@@ -143,7 +143,7 @@ jobs:
           pytest -v --pyargs $MODULE_NAME
 
   build_windows:
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     strategy:
       matrix:
@@ -181,6 +181,9 @@ jobs:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
 
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
       - name: Build conda package with NumPy 2.0
         run: |
           conda activate
@@ -209,7 +212,7 @@ jobs:
         python_ver: ['3.9', '3.10', '3.11', '3.12']
         numpy: ['numpy"<2"', 'numpy">=2"']
         experimental: [false]
-        runner: [windows-2019]
+        runner: [windows-latest]
     continue-on-error: ${{ matrix.experimental }}
     env:
       workdir: '${{ github.workspace }}'

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -151,7 +151,7 @@ jobs:
           pytest -v --pyargs $MODULE_NAME
 
   build_windows:
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     strategy:
       matrix:
@@ -191,6 +191,9 @@ jobs:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
 
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
       - name: Build conda package
         run: |
           conda activate
@@ -218,7 +221,7 @@ jobs:
       matrix:
         python: ['3.9', '3.10', '3.11', '3.12']
         experimental: [false]
-        runner: [windows-2019]
+        runner: [windows-latest]
     continue-on-error: ${{ matrix.experimental }}
     env:
       workdir: '${{ github.workspace }}'


### PR DESCRIPTION
The Windows Server 2019 image will be removed on 2025-06-30 https://github.com/actions/runner-images/issues/12045 and currently there is a scheduled Windows Server 2019 brownout.

In this PR, windows-latest is used in GitHub Actions.
In addition, a step is added to Setup MSVC otherwise `cl.exe` is not recognized.
 `error: command 'cl.exe' failed: None`