### PR TITLE
relax the condition for mkl-devel version for python 3.10

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
       - python
       - setuptools >=77
       - mkl-devel
-      - mkl-devel 2024.2.*  # [py==39 or py==310]
+      - mkl-devel 2024.2.*  # [py==39]
       - cython
       - numpy-base
     run:


### PR DESCRIPTION
scipy-1.15.2 is now available on `https://software.repos.intel.com/python/conda` for python 3.10.
So we can relax the condition for mkl-devel version for python 3.10.

Previously, the only scipy available for python 3.10 from `https://software.repos.intel.com/python/conda` was scipy=1.10.1 which required `mkl>=2024.2,<2025`.