### PR TITLE
Add description to the recipe to meet internal validation checks

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -48,7 +48,7 @@ about:
     home: http://github.com/IntelPython/mkl_fft
     license: BSD-3-Clause
     license_file: LICENSE.txt
-    summary: NumPy-based implementation of Fast Fourier Transform using Intel® oneAPI Math Kernel Library (OneMKL)
+    summary: NumPy-based implementation of Fast Fourier Transform using Intel® oneAPI Math Kernel Library (oneMKL)
     description: |
         <strong>LEGAL NOTICE: Use of this software package is subject to the
         software license agreement (as set forth above, in the license section of

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -49,3 +49,12 @@ about:
     license: BSD-3-Clause
     license_file: LICENSE.txt
     summary: NumPy-based implementation of Fast Fourier Transform using Intel® oneAPI Math Kernel Library (OneMKL)
+    description: |
+        <strong>LEGAL NOTICE: Use of this software package is subject to the
+        software license agreement (as set forth above, in the license section of
+        the installed Conda package and/or the README file) and all notices,
+        disclaimers or license terms for third party or open source software
+        included in or with the software.</strong>
+        <br/><br/>
+        EULA: <a href="https://opensource.org/licenses/BSD-3-Clause" target="_blank">BSD-3-Clause</a>
+        <br/><br/>


### PR DESCRIPTION
Internal validation requires field `description` in the recipe to be successful