### PR TITLE
[MAINT] Bump version to 2.2.0dev7

### DIFF
--- a/mkl_fft/_version.py
+++ b/mkl_fft/_version.py
@@ -1,1 +1,1 @@
-__version__ = "2.2.0dev6"
+__version__ = "2.2.0dev7"


### PR DESCRIPTION
This PR bumps `mkl_fft` version to 2.2.0dev7