### PR TITLE
Drop PyPI `mkl` runtime dep (fixes downstream `pip check`)

### DIFF
--- a/conda-recipe-cf/meta.yaml
+++ b/conda-recipe-cf/meta.yaml
@@ -31,8 +31,10 @@ requirements:
 
 test:
     commands:
+      - pip check
       - pytest -v --pyargs mkl_fft
     requires:
+      - pip
       - pytest
       - scipy >=1.10
       - mkl-service

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ classifiers = [
   "Operating System :: POSIX",
   "Operating System :: Unix"
 ]
-dependencies = ["numpy>=1.26.4", "mkl"]
+dependencies = ["numpy>=1.26.4"]
 description = "MKL-based FFT transforms for NumPy arrays"
 dynamic = ["version"]
 keywords = ["DFTI", "FFT", "Fourier", "MKL"]


### PR DESCRIPTION
`mkl` wheels are not distributed with `.dist-info`, so using `mkl` as a runtime dependency in `pyproject.toml` breaks `pip check` in any environment where `mkl` is installed via conda (which ships no dist-info).

This was first introduced in the same upstream change that affected `mkl-service` (fixed in IntelPython/mkl-service#201). This PR applies the same fix here: drop `mkl` from `[project].dependencies` — the conda `run:` dependency already ensures the runtime is present.

Fixes downstream `pip check` failures in conda-forge environments.