### PR TITLE
Apply RPATH logic for OSX

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -29,8 +29,13 @@ cc = meson.get_compiler('c')
 c_args = ['-DNDEBUG']
 
 rpath_link_args = []
-if host_machine.system() == 'linux'
-    rpath = '$ORIGIN' / '../..' + ':' + '$ORIGIN' / '../../..'
+if host_machine.system() != 'windows'
+    if host_machine.system() == 'darwin'
+        origin = '@loader_path'
+    else
+        origin = '$ORIGIN'
+    endif
+    rpath = origin / '../..' + ':' + origin / '../../..'
     rpath_link_args = ['-Wl,-rpath,' + rpath]
 endif
 


### PR DESCRIPTION
This PR fixes an oversight when mkl_fft was updated to use meson-python, namely, that mkl_fft is built for OSX on conda-forge. Logic for the RPATH was removed.

This PR reverts that change, aligning to mkl-service