### PR TITLE
Fix macOS rpath: emit one -rpath per path instead of colon-joining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+
+## [2.3.2] - 2026-08-04
+
+### Fixed
+* Emit one `-rpath` linker argument per path instead of colon-joining them, so the runtime library search path is baked correctly into macOS (Mach-O) extensions [gh-358](https://github.com/IntelPython/mkl_fft/pull/358)
+
 ## [2.3.1] - 2026-07-31
 
 ### Fixed

--- a/meson.build
+++ b/meson.build
@@ -35,8 +35,11 @@ if host_machine.system() != 'windows'
     else
         origin = '$ORIGIN'
     endif
-    rpath = origin / '../..' + ':' + origin / '../../..'
-    rpath_link_args = ['-Wl,-rpath,' + rpath]
+
+    rpath_link_args = [
+        '-Wl,-rpath,' + origin / '../..',
+        '-Wl,-rpath,' + origin / '../../..',
+    ]
 endif
 
 mkl_dep = dependency('MKL', method: 'cmake',


### PR DESCRIPTION
In #351 the extensions' runtime search path by colon-joining two paths into a single -Wl,-rpath, argument:
```
-Wl,-rpath,$ORIGIN/../..:$ORIGIN/../../..
```

Colon-as-separator is an **ELF/Linux** convention. On macOS (Mach-O) each `-rpath` produces exactly one `LC_RPATH` load command and the string is taken **verbatim** — the colon is not a separator. As a result, macOS extensions shipped a single unusable rpath entry:
```
LC_RPATH: @loader_path/../..:@loader_path/../../..   ← no such directory
```

This PR emits one `-Wl,-rpath,` argument per path, restoring the exact per-entry behavior of the legacy `setup.py` (`runtime_library_dirs=["$ORIGIN/../..", "$ORIGIN/../../.."]`). This is correct on both Mach-O and ELF.
