### PR TITLE
Fix Coverity OVERRUN false positive in _allocate_result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+* Declared `f_ndim` as a C `int` in `_allocate_result` so the buffer size is computed in C rather than through a Python object, resolving a Coverity out-of-bounds (OVERRUN) false positive [gh-364](https://github.com/IntelPython/mkl_fft/pull/364)
 
 ## [2.3.2] - 2026-08-04
 

--- a/mkl_fft/_pydfti.pyx
+++ b/mkl_fft/_pydfti.pyx
@@ -302,6 +302,7 @@ cdef cnp.ndarray _allocate_result(
     cdef cnp.npy_intp *f_shape
     cdef cnp.ndarray f_arr "ff_arrayObject"
     cdef int x_arr_is_fortran
+    cdef int f_ndim
 
     f_ndim = cnp.PyArray_NDIM(x_arr)
 


### PR DESCRIPTION
## Summary

Fixes a Coverity **out-of-bounds access (OVERRUN)** finding reported in `__pyx_f_7mkl_fft_7_pydfti__allocate_result`.

The finding is a false positive, but it stems from a real code-quality issue: `f_ndim` in `_allocate_result` was left untyped, so it was a Python object rather than a C `int`.

## Root cause

Because `f_ndim` was a Python object, the expression `f_ndim * sizeof(cnp.npy_intp)` was compiled as a Python-level multiplication (`PyNumber_Multiply`) followed by `__Pyx_PyLong_As_size_t`. That conversion returns the error sentinel `(size_t)-1` (`18446744073709551615`) on failure. Coverity explored the path where the sentinel reaches `PyMem_Malloc`/`memcpy` without a Python exception being set, and reported an out-of-bounds write on `f_shape`.

That state is unreachable at runtime — `f_ndim` is a NumPy array's number of dimensions (0–64) — but the analyzer cannot prove it once the value is laundered through a `PyObject`.

Tellingly, the structurally identical `memcpy` in `_pad_array` was **not** flagged, because its `b_ndim` is already declared `cdef int`.

## Fix

Declare `f_ndim` as `cdef int`, matching `b_ndim` in `_pad_array`. The size is then computed as a plain C multiplication, and the `__Pyx_PyLong_As_size_t` sentinel path disappears entirely from the generated C.
