### PR TITLE
fix: silence Coverity UNUSED_VALUE in __create_descriptor_1d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+* Silenced a Coverity `UNUSED_VALUE` finding in `__create_descriptor_1d` by marking the `DftiFreeDescriptor` status (used only by a debug-only `assert`) as intentionally unused
 
 ## [2.3.2] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
-* Silenced a Coverity `UNUSED_VALUE` finding in `__create_descriptor_1d` by marking the `DftiFreeDescriptor` status (used only by a debug-only `assert`) as intentionally unused
+* Silenced a Coverity `UNUSED_VALUE` finding in `__create_descriptor_1d` by marking the `DftiFreeDescriptor` status (used only by a debug-only `assert`) as intentionally unused [gh-365](https://github.com/IntelPython/mkl_fft/pull/365)
 
 ## [2.3.2] - 2026-08-04
 

--- a/mkl_fft/src/mklfft.c.src
+++ b/mkl_fft/src/mklfft.c.src
@@ -170,6 +170,7 @@ __create_descriptor_1d_@prec@_@domain@(MKL_LONG len, @sc_t@ fsc, @sc_t@ bsc, Dft
     if(dfti_cache->hand) {
         status = DftiFreeDescriptor(&(dfti_cache->hand));
         assert(status == 0);
+        (void)status;  /* used only by assert; ignored under NDEBUG */
     }
 
     status = 0;


### PR DESCRIPTION
The PR resolves the Coverity **UNUSED_VALUE** (CWE-563) findings in `__create_descriptor_1d_*`.

On the `reallocate:` path in [mkl_fft/src/mklfft.c.src](mkl_fft/src/mklfft.c.src), the value returned by `DftiFreeDescriptor` is stored into `status` but consumed only by the debug-only `assert(status == 0)`. Under `NDEBUG` the assert is compiled out, so the store is dead before the unconditional `status = 0;` reset — which Coverity flags.

The behavior is correct as written (the old handle's free status is irrelevant since a fresh descriptor is built next). This marks the value as intentionally unused with `(void)status;` to make the intent explicit and clear the finding.
