### PR TITLE
ASV: Track dev-milestone alongside master in benchmark dashboard

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -5,7 +5,8 @@
     "show_commit_url": "https://github.com/IntelPython/mkl_fft/commit/",
     "repo": "..",
     "branches": [
-        "master"
+        "master",
+        "dev-milestone"
     ],
     "environment_type": "conda",
     "conda_channels": [

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -1,2 +1,3 @@
 psutil
+mkl-service
 scipy>=1.10


### PR DESCRIPTION
  `benchmarks/asv.conf.json` lists only `master` in `branches`. Nightly benchmarking now also
  runs `dev-milestone`, and `asv publish` only graphs commits reachable from a branch in that
  list, so dev-milestone results are computed and stored but silently dropped from the dashboard.

  Adds `dev-milestone` to `branches` so both get their own trend line on the dashboards.
  
  Post merge, need this pr backported to dev-milestone